### PR TITLE
docs: fix build command and ignore compiled binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ output-samples/
 # ai stuff
 .claude.local.me
 .serena/
+/reposcan

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ RepoScan is a Go CLI tool that scans filesystems for Git repositories and report
 ### Building
 ```bash
 # Build the main binary
-go build -o reposcan ./cmd/reposcan
+go build -o reposcan .
 
 # Install to $GOPATH/bin
 go install github.com/mabd-dev/reposcan@latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,15 +36,15 @@ go test -v -run TestName ./path/to/package
 ### Running
 ```bash
 # Run with default settings (scans $HOME)
-go run ./cmd/reposcan
+go run .
 
 # Run with custom root
-go run ./cmd/reposcan -r ~/Code
+go run . -r ~/Code
 
 # Run with specific output format
-go run ./cmd/reposcan -o interactive
-go run ./cmd/reposcan -o table
-go run ./cmd/reposcan -o json
+go run . -o interactive
+go run . -o table
+go run . -o json
 ```
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Make sure $GOPATH/bin (or $HOME/go/bin) is in your $PATH.
 ```sh
 git clone https://github.com/mabd-dev/reposcan.git
 cd reposcan
-go build -o reposcan ./cmd/reposcan
+go build -o reposcan .
 ```
 
 


### PR DESCRIPTION
Update build command from `go build -o reposcan ./cmd/reposcan` to `go build -o reposcan .` in README.md and CLAUDE.md to reflect that main.go lives at the repo root. Also add `/reposcan` to .gitignore to prevent the compiled binary from being accidentally committed.

fixes #13