### PR TITLE
fix: hide redundant remote name in state column

### DIFF
--- a/internal/render/tui/repostable/ui.go
+++ b/internal/render/tui/repostable/ui.go
@@ -67,8 +67,10 @@ func getStateColumnStr(rs report.RepoState, theme theme.Theme) string {
 			statusParts = append(statusParts, fmt.Sprintf("↓%-d", 0))
 		}
 
-		remoteName := theme.Styles.Base.Render(fmt.Sprintf("(%s)", remoteStatus.Remote))
-		statusParts = append(statusParts, remoteName)
+		if remoteStatus.Remote != "" && !(len(rs.RemoteStatus) == 1 && remoteStatus.Remote == "origin") {
+			remoteName := theme.Styles.Base.Render(fmt.Sprintf("(%s)", remoteStatus.Remote))
+			statusParts = append(statusParts, remoteName)
+		}
 
 		parts = append(parts, strings.Join(statusParts, " "))
 	}


### PR DESCRIPTION
## Summary

- Skips rendering the remote name `(origin)` when there is only one remote and it is named "origin"
- Skips rendering empty parentheses `()` when no remote name is set
- Multiple remotes still show their names to disambiguate

Closes #20

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [ ] Repo with single "origin" remote: state column shows `⏳0 ↑0 ↓0` without `(origin)`
- [ ] Repo with multiple remotes: state column still shows remote names
- [ ] Repo with no remote: no empty parentheses