### PR TITLE
Feat/telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 
-## [1.3.8] - 2026-04-27
+## [1.3.8-alpha] - 2026-04-27
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+- feat/telemetry send anonymous telemetry usage by @mabd-dev
+
 
 ## [1.3.8-alpha] - 2026-04-27
 

--- a/README.md
+++ b/README.md
@@ -175,5 +175,27 @@ Each step overrides the one before it
 - [ ] Show branches with their states on each repo
 
 
+## Telemetry
+
+reposcan collects anonymous usage data to help understand how the tool is used and improve it over time.
+You'll see a one-time notice about this on first run.
+
+What is collected:
+- `os` — operating system (linux, windows, darwin)
+- `arch` — device cpu architecture 
+- `tool-version` — tool version being used
+- `ci` — whether the tool is running in a CI environment
+
+and other tool specific cli-flags like `filter`, `output_format`, `repo_count`
+
+Nothing personal is collected — no usernames, tokens, or file paths.
+Events are sent to a [mixpanel](https://mixpanel.com/home/) (a third-party analytics service) and visible only to the maintainer.
+
+
+### Disable telemetry
+
+Add `--no-telemetry` when running the command. Or in `~/.config/reposcan/config.toml` add `no-telemetry = true` at the top of the file (check [sample.toml](sample/config.toml))
+
+
 ## 🤝 Contributing
 PRs, bug reports, and feature requests are welcome.

--- a/cmd/reposcan/flags_read_test.go
+++ b/cmd/reposcan/flags_read_test.go
@@ -20,6 +20,7 @@ func TestReadFlags_AppliesAllFlags(t *testing.T) {
 	cmd.Flags().String("json-output-path", "", "")
 	cmd.Flags().IntP("max-workers", "w", 8, "")
 	cmd.Flags().BoolP("debug", "", false, "")
+	cmd.Flags().BoolP("no-telemetry", "", false, "")
 	// cmd.Flags().StringP("colorscheme", "", "", "")
 
 	args := []string{
@@ -31,7 +32,8 @@ func TestReadFlags_AppliesAllFlags(t *testing.T) {
 		"-f", "all",
 		"--json-output-path", "/tmp/out",
 		"-w", "16",
-		"--debug", "true",
+		"--debug=true",
+		"--no-telemetry=false",
 		// "--colorscheme", "something",
 	}
 	cmd.SetArgs(args)
@@ -66,7 +68,10 @@ func TestReadFlags_AppliesAllFlags(t *testing.T) {
 		t.Fatalf("max workers not applied: %d", cfg.MaxWorkers)
 	}
 	if cfg.Debug != true {
-		t.Fatalf("debugnot applied: %t", cfg.Debug)
+		t.Fatalf("debug not applied: %t", cfg.Debug)
+	}
+	if cfg.NoTelemetry != false {
+		t.Fatalf("telemetry not applied: %t", cfg.Debug)
 	}
 }
 
@@ -92,6 +97,7 @@ func TestReadTableOutput_SwitchToInteractiveOutput(t *testing.T) {
 	cmd.Flags().String("json-output-path", "", "")
 	cmd.Flags().IntP("max-workers", "w", 8, "")
 	cmd.Flags().BoolP("debug", "", false, "")
+	cmd.Flags().BoolP("no-telemetry", "", false, "")
 	// cmd.Flags().StringP("colorscheme", "", "", "")
 
 	args := []string{
@@ -103,7 +109,8 @@ func TestReadTableOutput_SwitchToInteractiveOutput(t *testing.T) {
 		"-f", "all",
 		"--json-output-path", "/tmp/out",
 		"-w", "16",
-		"--debug", "true",
+		"--debug=true",
+		"no-telemetry=false",
 		// "--colorscheme", "something",
 	}
 	cmd.SetArgs(args)

--- a/cmd/reposcan/flags_read_test.go
+++ b/cmd/reposcan/flags_read_test.go
@@ -110,7 +110,7 @@ func TestReadTableOutput_SwitchToInteractiveOutput(t *testing.T) {
 		"--json-output-path", "/tmp/out",
 		"-w", "16",
 		"--debug=true",
-		"no-telemetry=false",
+		"--no-telemetry=false",
 		// "--colorscheme", "something",
 	}
 	cmd.SetArgs(args)

--- a/cmd/reposcan/flags_read_test.go
+++ b/cmd/reposcan/flags_read_test.go
@@ -71,7 +71,7 @@ func TestReadFlags_AppliesAllFlags(t *testing.T) {
 		t.Fatalf("debug not applied: %t", cfg.Debug)
 	}
 	if cfg.NoTelemetry != false {
-		t.Fatalf("telemetry not applied: %t", cfg.Debug)
+		t.Fatalf("telemetry not applied: %t", cfg.NoTelemetry)
 	}
 }
 

--- a/cmd/reposcan/main.go
+++ b/cmd/reposcan/main.go
@@ -39,6 +39,7 @@ func init() {
 	RootCmd.PersistentFlags().String("json-output-path", configs.Output.JSONPath, "Write scan report JSON files to this directory (optional)")
 	RootCmd.PersistentFlags().IntP("max-workers", "w", configs.MaxWorkers, "Number of concurrent git checks")
 	RootCmd.PersistentFlags().BoolP("debug", "", configs.Debug, "Enable/Disable debug mode")
+	RootCmd.PersistentFlags().BoolP("no-telemetry", "", configs.NoTelemetry, "Enable/Disable sending telemetry")
 	// RootCmd.PersistentFlags().StringP("colorscheme", "", configs.Output.ColorSchemeName, "Used only if 'output' is 'interactive'")
 
 	RootCmd.AddCommand(versionCmd)

--- a/cmd/reposcan/rootCmd.go
+++ b/cmd/reposcan/rootCmd.go
@@ -153,7 +153,7 @@ func run(configs config.Config) error {
 	report := internal.GenerateScanReport(configs)
 
 	if !configs.NoTelemetry {
-		telemetry.Send(mixpanelToken, configs.Debug, configs.Only, configs.Output.Type, len(report.RepoStates), 0)
+		telemetry.Send(mixpanelToken, configs.Debug, configs.Only, configs.Output.Type, len(report.RepoStates))
 	}
 
 	switch configs.Output.Type {

--- a/cmd/reposcan/rootCmd.go
+++ b/cmd/reposcan/rootCmd.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mabd-dev/reposcan/internal/render/file"
 	"github.com/mabd-dev/reposcan/internal/render/stdout"
 	"github.com/mabd-dev/reposcan/internal/render/tui"
+	"github.com/mabd-dev/reposcan/internal/telemetry"
 	"github.com/spf13/cobra"
 )
 
@@ -72,6 +73,7 @@ var RootCmd = &cobra.Command{
 //   - max-workers (-w)     		: number of concurrent git checks
 //   - debug (--debug)      		: enable/disable debug mode
 //   - colorscheme (--colorscheme)  : enable/disable debug mode
+//   - no-telemetry					: enable/disable sending telemetry data
 func readFlags(cmd *cobra.Command, configs *config.Config) error {
 	// Read roots flags
 	roots, err := cmd.Flags().GetStringArray("root")
@@ -138,11 +140,21 @@ func readFlags(cmd *cobra.Command, configs *config.Config) error {
 	}
 	(*configs).Debug = debug
 
+	noTelemetry, err := cmd.Flags().GetBool("no-telemetry")
+	if err != nil {
+		return err
+	}
+	(*configs).NoTelemetry = noTelemetry
+
 	return nil
 }
 
 func run(configs config.Config) error {
 	report := internal.GenerateScanReport(configs)
+
+	if !configs.NoTelemetry {
+		telemetry.Send(configs.Only, configs.Output.Type, len(report.RepoStates), 0)
+	}
 
 	switch configs.Output.Type {
 	case config.OutputJson:

--- a/cmd/reposcan/rootCmd.go
+++ b/cmd/reposcan/rootCmd.go
@@ -153,7 +153,7 @@ func run(configs config.Config) error {
 	report := internal.GenerateScanReport(configs)
 
 	if !configs.NoTelemetry {
-		telemetry.Send(configs.Only, configs.Output.Type, len(report.RepoStates), 0)
+		telemetry.Send(mixpanelToken, configs.Debug, configs.Only, configs.Output.Type, len(report.RepoStates), 0)
 	}
 
 	switch configs.Output.Type {

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -60,3 +60,8 @@ This document explains each CLI flag, its equivalent `config.toml` field, what i
   - Config: `debug = true/false`
   - Description: Enable/disable logging mode. Log file will be in `~/.config/reposcan/logs/`
   - Example: `--debug=false` or `--debug` same as `--debug=true`
+
+- `--no-telemetry true/false`
+  - Config: `no-telemetry = true/false`
+  - Description: Enable/disable sending telemetry data
+  - Example: `--no-telemetry=true` or `--no-telemetry`

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/fatih/color v1.18.0
+	github.com/google/uuid v1.6.0
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/mixpanel/mixpanel-go v1.2.1
 	github.com/muesli/reflow v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=
 github.com/fatih/color v1.18.0/go.mod h1:4FelSpRwEGDpQ12mAdzqdOukCy4u8WUtOY6lkT/6HfU=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jarcoal/httpmock v1.3.1 h1:iUx3whfZWVf3jT01hQTO/Eo5sAYtB2/rqaUuOtpInww=

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -15,7 +15,8 @@ type Config struct {
 	MaxWorkers int `toml:"maxWorkers"`
 
 	// Debug if true, enable logging to a file in [DefaultLogFileDir]
-	Debug bool `toml:"debug"`
+	Debug       bool `toml:"debug"`
+	NoTelemetry bool `toml:"no-telemetry"`
 
 	Version int `toml:"version"`
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -38,11 +38,10 @@ func Send(
 	filter config.OnlyFilter,
 	outputFormat config.OutputFormat,
 	repoCount int,
-	scanDurationMs int,
 ) {
 	isCI := os.Getenv("CI") != ""
 	if isCI {
-		fmt.Fprintln(stdout, "Send telemetry")
+		sendTelemetry(token, debug, filter, outputFormat, repoCount)
 		return
 	}
 
@@ -66,9 +65,19 @@ func Send(
 		writeTelemetry(filePath, telemetry)
 	}
 
+	sendTelemetry(token, debug, filter, outputFormat, repoCount)
+}
+
+func sendTelemetry(
+	token string,
+	debug bool,
+	filter config.OnlyFilter,
+	outputFormat config.OutputFormat,
+	repoCount int,
+) {
 	analyticsService := newAnalyticsService(token, debug)
 
-	err = analyticsService.Send("usage", map[string]any{
+	err := analyticsService.Send("usage", map[string]any{
 		"os":            runtime.GOOS,
 		"arch":          runtime.GOARCH,
 		"filter":        filter,

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -18,8 +19,11 @@ import (
 )
 
 var (
-	toolName         = "reposcan"
-	telemtryFileName = "telemetry.json"
+	toolName                      = "reposcan"
+	telemtryFileName              = "telemetry.json"
+	userConfigDir                 = os.UserConfigDir
+	newAnalyticsService           = analytics.New
+	stdout              io.Writer = os.Stdout
 )
 
 type Telemetry struct {
@@ -36,9 +40,13 @@ func Send(
 	repoCount int,
 	scanDurationMs int,
 ) {
+
+	fmt.Printf("token=%v\n", token)
+	fmt.Printf("debug=%v\n", debug)
+
 	isCI := os.Getenv("CI") != ""
 	if isCI {
-		fmt.Println("Send telemetry")
+		fmt.Fprintln(stdout, "Send telemetry")
 		return
 	}
 
@@ -53,16 +61,16 @@ func Send(
 	}
 
 	if !telemetry.Warned {
-		fmt.Println("reposcan collects anonymous usage telemetry to help improve the tool.")
-		fmt.Println("No personal data or file paths are collected.")
-		fmt.Println("To disable: pass --no-telemetry")
-		fmt.Println("More info: https://github.com/mabd-dev/reposcan#telemetry")
+		fmt.Fprintln(stdout, "reposcan collects anonymous usage telemetry to help improve the tool.")
+		fmt.Fprintln(stdout, "No personal data or file paths are collected.")
+		fmt.Fprintln(stdout, "To disable: pass --no-telemetry")
+		fmt.Fprintln(stdout, "More info: https://github.com/mabd-dev/reposcan#telemetry")
 
 		telemetry.Warned = true
 		writeTelemetry(filePath, telemetry)
 	}
 
-	analyticsService := analytics.New(token, debug)
+	analyticsService := newAnalyticsService(token, debug)
 
 	err = analyticsService.Send("usage", map[string]any{
 		"os":            runtime.GOOS,
@@ -103,13 +111,13 @@ func getOrCreateTelemetry(filePath string) (Telemetry, error) {
 }
 
 func getTelemetryFilePath() (string, error) {
-	configDir, err := os.UserConfigDir()
+	configDir, err := userConfigDir()
 	if err != nil {
 		return "", err
 	}
 
 	dir := filepath.Join(configDir, toolName)
-	if err := os.Mkdir(dir, 0755); err != nil {
+	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
 	}
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,0 +1,22 @@
+package telemetry
+
+import (
+	"fmt"
+
+	"github.com/mabd-dev/reposcan/internal/config"
+)
+
+type Telemetry struct {
+	UUID   string `json:"uuid"`
+	Warned string `json:"warned"`
+}
+
+// Send send telemetry usage to analytics service
+func Send(
+	filter config.OnlyFilter,
+	outputFormat config.OutputFormat,
+	repoCount int,
+	scanDurationMs int,
+) {
+	fmt.Println("sending telemtry")
+}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -41,7 +41,7 @@ func Send(
 ) {
 	isCI := os.Getenv("CI") != ""
 	if isCI {
-		sendTelemetry(token, debug, filter, outputFormat, repoCount)
+		sendTelemetry(token, debug, filter, outputFormat, repoCount, isCI)
 		return
 	}
 
@@ -65,7 +65,7 @@ func Send(
 		writeTelemetry(filePath, telemetry)
 	}
 
-	sendTelemetry(token, debug, filter, outputFormat, repoCount)
+	sendTelemetry(token, debug, filter, outputFormat, repoCount, isCI)
 }
 
 func sendTelemetry(
@@ -74,12 +74,14 @@ func sendTelemetry(
 	filter config.OnlyFilter,
 	outputFormat config.OutputFormat,
 	repoCount int,
+	isCI bool,
 ) {
 	analyticsService := newAnalyticsService(token, debug)
 
 	err := analyticsService.Send("usage", map[string]any{
 		"os":            runtime.GOOS,
 		"arch":          runtime.GOARCH,
+		"ci":            isCI,
 		"filter":        filter,
 		"output_format": outputFormat,
 		"repo_count":    repoCount,
@@ -95,7 +97,7 @@ func sendTelemetry(
 func getOrCreateTelemetry(filePath string) (Telemetry, error) {
 	exists, err := fileExists(filePath)
 	if err != nil {
-		return Telemetry{}, nil
+		return Telemetry{}, err
 	}
 
 	if exists {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -40,10 +40,6 @@ func Send(
 	repoCount int,
 	scanDurationMs int,
 ) {
-
-	fmt.Printf("token=%v\n", token)
-	fmt.Printf("debug=%v\n", debug)
-
 	isCI := os.Getenv("CI") != ""
 	if isCI {
 		fmt.Fprintln(stdout, "Send telemetry")

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -33,6 +33,13 @@ func Send(
 	}
 
 	// TODO: if !warned -> warn user
+	warned := false
+	if !warned {
+		fmt.Println("reposcan collects anonymous usage telemetry to help improve the tool.")
+		fmt.Println("No personal data or file paths are collected.")
+		fmt.Println("To disable: pass --no-telemetry")
+		fmt.Println("More info: https://github.com/mabd-dev/reposcan#telemetry")
+	}
 
 	analyticsService := analytics.New(token, debug)
 

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -2,19 +2,29 @@
 package telemetry
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
+	"strings"
 
+	"github.com/google/uuid"
 	"github.com/mabd-dev/reposcan/internal"
 	"github.com/mabd-dev/reposcan/internal/analytics"
 	"github.com/mabd-dev/reposcan/internal/config"
 	"github.com/mabd-dev/reposcan/internal/logger"
 )
 
+var (
+	toolName         = "reposcan"
+	telemtryFileName = "telemetry.json"
+)
+
 type Telemetry struct {
 	UUID   string `json:"uuid"`
-	Warned string `json:"warned"`
+	Warned bool   `json:"warned"`
 }
 
 // Send send telemetry usage to analytics service
@@ -32,28 +42,148 @@ func Send(
 		return
 	}
 
-	// TODO: if !warned -> warn user
-	warned := false
-	if !warned {
+	filePath, err := getTelemetryFilePath()
+	if err != nil {
+		logger.Error("Failed to get telemetry file path, error=%v", err.Error())
+		return
+	}
+	telemetry, err := getOrCreateTelemetry(filePath)
+	if err != nil {
+		return
+	}
+
+	if !telemetry.Warned {
 		fmt.Println("reposcan collects anonymous usage telemetry to help improve the tool.")
 		fmt.Println("No personal data or file paths are collected.")
 		fmt.Println("To disable: pass --no-telemetry")
 		fmt.Println("More info: https://github.com/mabd-dev/reposcan#telemetry")
+
+		telemetry.Warned = true
+		writeTelemetry(filePath, telemetry)
 	}
 
 	analyticsService := analytics.New(token, debug)
 
-	err := analyticsService.Send("usage", map[string]any{
+	err = analyticsService.Send("usage", map[string]any{
 		"os":            runtime.GOOS,
 		"arch":          runtime.GOARCH,
 		"filter":        filter,
 		"output_format": outputFormat,
 		"repo_count":    repoCount,
 		"tool-version":  internal.VERSION,
-		"project":       "reposcan",
+		"project":       toolName,
 	})
 
 	if err != nil {
 		logger.Error("Failed to send analytics, error")
 	}
+}
+
+func getOrCreateTelemetry(filePath string) (Telemetry, error) {
+	exists, err := fileExists(filePath)
+	if err != nil {
+		return Telemetry{}, nil
+	}
+
+	if exists {
+		telemetry, err := readTelemetry(filePath)
+		if err != nil {
+			logger.Error("Failed to read telemetry, error=%v", err.Error())
+			return Telemetry{}, nil
+		}
+		return telemetry, nil
+	}
+
+	telemetry := Telemetry{
+		UUID:   uuid.New().String(),
+		Warned: false,
+	}
+	writeTelemetry(filePath, telemetry)
+	return telemetry, nil
+}
+
+func getTelemetryFilePath() (string, error) {
+	configDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+
+	dir := filepath.Join(configDir, toolName)
+	if err := os.Mkdir(dir, 0755); err != nil {
+		return "", err
+	}
+
+	filePath := filepath.Join(dir, telemtryFileName)
+	return filePath, nil
+}
+
+func readTelemetry(filepath string) (Telemetry, error) {
+	data, err := os.ReadFile(filepath)
+	if err != nil {
+		return Telemetry{}, err
+	}
+
+	var telemetry Telemetry
+	if err := json.Unmarshal(data, &telemetry); err != nil {
+		return Telemetry{}, err
+	}
+
+	return telemetry, nil
+}
+
+func writeTelemetry(filePath string, telemetry Telemetry) error {
+	data, err := json.MarshalIndent(telemetry, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	path, err := expandPath(filePath)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, data, 0o644)
+}
+
+// FileExists checks if a file exists at the given path.
+// Returns (true, nil) if the file exists,
+// (false, nil) if it does not exist,
+// or (false, err) if an error other than "not exist" occurs.
+func fileExists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err == nil {
+		// file already exists, do nothing
+		return true, nil
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		// file not found
+		return false, nil
+	}
+
+	return false, err
+}
+
+// expandPath expands a filesystem path that may start with '~' into an
+// absolute path using the current user's home directory.
+//
+// Examples:
+//
+//	expandPath("~/Documents/file.txt")   -> "/Users/someone/Documents/file.txt"
+//	expandPath("/tmp/file.txt")          -> "/tmp/file.txt"
+//
+// Only a leading '~' is expanded. If the path does not start with '~',
+// it is returned unchanged.
+//
+// Returns the expanded absolute path or an error if the home directory
+// cannot be determined.
+func expandPath(path string) (string, error) {
+	if strings.HasPrefix(path, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(home, path[1:]), nil
+	}
+	return path, nil
 }

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -102,7 +102,7 @@ func getOrCreateTelemetry(filePath string) (Telemetry, error) {
 		telemetry, err := readTelemetry(filePath)
 		if err != nil {
 			logger.Error("Failed to read telemetry, error=%v", err.Error())
-			return Telemetry{}, nil
+			return Telemetry{}, err
 		}
 		return telemetry, nil
 	}

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -1,9 +1,15 @@
+// Package telemetry used to send telemetry usage to mixpanel
 package telemetry
 
 import (
 	"fmt"
+	"os"
+	"runtime"
 
+	"github.com/mabd-dev/reposcan/internal"
+	"github.com/mabd-dev/reposcan/internal/analytics"
 	"github.com/mabd-dev/reposcan/internal/config"
+	"github.com/mabd-dev/reposcan/internal/logger"
 )
 
 type Telemetry struct {
@@ -13,10 +19,34 @@ type Telemetry struct {
 
 // Send send telemetry usage to analytics service
 func Send(
+	token string,
+	debug bool,
 	filter config.OnlyFilter,
 	outputFormat config.OutputFormat,
 	repoCount int,
 	scanDurationMs int,
 ) {
-	fmt.Println("sending telemtry")
+	isCI := os.Getenv("CI") != ""
+	if isCI {
+		fmt.Println("Send telemetry")
+		return
+	}
+
+	// TODO: if !warned -> warn user
+
+	analyticsService := analytics.New(token, debug)
+
+	err := analyticsService.Send("usage", map[string]any{
+		"os":            runtime.GOOS,
+		"arch":          runtime.GOARCH,
+		"filter":        filter,
+		"output_format": outputFormat,
+		"repo_count":    repoCount,
+		"tool-version":  internal.VERSION,
+		"project":       "reposcan",
+	})
+
+	if err != nil {
+		logger.Error("Failed to send analytics, error")
+	}
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,432 @@
+package telemetry
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mabd-dev/reposcan/internal/analytics"
+	"github.com/mabd-dev/reposcan/internal/config"
+)
+
+// mockAnalytics records what was passed to Send.
+type mockAnalytics struct {
+	event      string
+	properties map[string]any
+	err        error
+}
+
+func (m *mockAnalytics) Send(event string, properties map[string]any) error {
+	m.event = event
+	m.properties = properties
+	return m.err
+}
+
+// setConfigDir overrides userConfigDir for the duration of the test.
+func setConfigDir(t *testing.T, dir string) {
+	t.Helper()
+	orig := userConfigDir
+	userConfigDir = func() (string, error) { return dir, nil }
+	t.Cleanup(func() { userConfigDir = orig })
+}
+
+// setConfigDirError overrides userConfigDir to return an error.
+func setConfigDirError(t *testing.T) {
+	t.Helper()
+	orig := userConfigDir
+	userConfigDir = func() (string, error) { return "", errors.New("no config dir") }
+	t.Cleanup(func() { userConfigDir = orig })
+}
+
+// setAnalytics overrides newAnalyticsService for the duration of the test.
+func setAnalytics(t *testing.T, mock *mockAnalytics) {
+	t.Helper()
+	orig := newAnalyticsService
+	newAnalyticsService = func(token string, debug bool) analytics.Analytics { return mock }
+	t.Cleanup(func() { newAnalyticsService = orig })
+}
+
+// captureStdout redirects the package-level stdout to a buffer.
+func captureStdout(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	orig := stdout
+	stdout = &buf
+	t.Cleanup(func() { stdout = orig })
+	return &buf
+}
+
+// writeTelemetryFile writes a Telemetry struct as JSON at the given path.
+func writeTelemetryFile(t *testing.T, path string, tel Telemetry) {
+	t.Helper()
+	data, err := json.MarshalIndent(tel, "", "    ")
+	if err != nil {
+		t.Fatalf("marshal telemetry: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write telemetry file: %v", err)
+	}
+}
+
+// ---- expandPath ----
+
+func TestExpandPath_TildeExpandsToHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot determine home dir: %v", err)
+	}
+	got, err := expandPath("~/foo/bar")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(home, "foo/bar")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestExpandPath_TildeOnly_ExpandsToHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot determine home dir: %v", err)
+	}
+	got, err := expandPath("~")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != home {
+		t.Errorf("got %q, want %q", got, home)
+	}
+}
+
+func TestExpandPath_AbsolutePath_Unchanged(t *testing.T) {
+	path := "/some/absolute/path"
+	got, err := expandPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != path {
+		t.Errorf("got %q, want %q", got, path)
+	}
+}
+
+func TestExpandPath_RelativePath_Unchanged(t *testing.T) {
+	path := "relative/path/file.txt"
+	got, err := expandPath(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != path {
+		t.Errorf("got %q, want %q", got, path)
+	}
+}
+
+// ---- fileExists ----
+
+func TestFileExists_ExistingFile_ReturnsTrue(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "telemetry-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	exists, err := fileExists(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected true for existing file, got false")
+	}
+}
+
+func TestFileExists_NonExistentFile_ReturnsFalse(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-such-file.json")
+	exists, err := fileExists(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exists {
+		t.Error("expected false for non-existent file, got true")
+	}
+}
+
+func TestFileExists_Directory_ReturnsTrue(t *testing.T) {
+	dir := t.TempDir()
+	exists, err := fileExists(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exists {
+		t.Error("expected true for directory, got false")
+	}
+}
+
+// ---- readTelemetry ----
+
+func TestReadTelemetry_ValidFile_ReturnsTelemetry(t *testing.T) {
+	want := Telemetry{UUID: "test-uuid-1234", Warned: true}
+	path := filepath.Join(t.TempDir(), "telemetry.json")
+	writeTelemetryFile(t, path, want)
+
+	got, err := readTelemetry(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestReadTelemetry_NonExistentFile_ReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-such.json")
+	_, err := readTelemetry(path)
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}
+
+func TestReadTelemetry_InvalidJSON_ReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "bad.json")
+	os.WriteFile(path, []byte("not-valid-json{{{"), 0o644)
+
+	_, err := readTelemetry(path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+// ---- writeTelemetry ----
+
+func TestWriteTelemetry_CreatesFileWithCorrectContent(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry.json")
+	want := Telemetry{UUID: "abc-123", Warned: true}
+
+	if err := writeTelemetry(path, want); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := readTelemetry(path)
+	if err != nil {
+		t.Fatalf("readTelemetry after write: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestWriteTelemetry_NonExistentDirectory_ReturnsError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subdir", "telemetry.json")
+	err := writeTelemetry(path, Telemetry{UUID: "x"})
+	if err == nil {
+		t.Fatal("expected error for non-existent parent directory, got nil")
+	}
+}
+
+// ---- getOrCreateTelemetry ----
+
+func TestGetOrCreateTelemetry_ExistingFile_ReturnsTelemetry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry.json")
+	want := Telemetry{UUID: "existing-uuid", Warned: true}
+	writeTelemetryFile(t, path, want)
+
+	got, err := getOrCreateTelemetry(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestGetOrCreateTelemetry_FileNotExists_CreatesNewWithUUID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry.json")
+
+	got, err := getOrCreateTelemetry(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.UUID == "" {
+		t.Error("expected non-empty UUID for new telemetry")
+	}
+	if got.Warned {
+		t.Error("new telemetry should have Warned=false")
+	}
+	if exists, _ := fileExists(path); !exists {
+		t.Error("telemetry file should have been written to disk")
+	}
+}
+
+func TestGetOrCreateTelemetry_TwoCalls_ProduceSameUUID(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry.json")
+
+	first, _ := getOrCreateTelemetry(path)
+	second, _ := getOrCreateTelemetry(path)
+	if first.UUID != second.UUID {
+		t.Errorf("UUID mismatch: %q vs %q", first.UUID, second.UUID)
+	}
+}
+
+func TestGetOrCreateTelemetry_InvalidJSON_ReturnsEmptyTelemetry(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "telemetry.json")
+	os.WriteFile(path, []byte("bad json{{"), 0o644)
+
+	got, err := getOrCreateTelemetry(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != (Telemetry{}) {
+		t.Errorf("expected empty Telemetry on bad JSON, got %+v", got)
+	}
+}
+
+// ---- getTelemetryFilePath ----
+
+func TestGetTelemetryFilePath_Success_ReturnsPathUnderToolSubdir(t *testing.T) {
+	tmpDir := t.TempDir()
+	setConfigDir(t, tmpDir)
+
+	path, err := getTelemetryFilePath()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expectedDir := filepath.Join(tmpDir, toolName)
+	if !strings.HasPrefix(path, expectedDir) {
+		t.Errorf("path %q should be under %q", path, expectedDir)
+	}
+	if !strings.HasSuffix(path, telemtryFileName) {
+		t.Errorf("path %q should end with %q", path, telemtryFileName)
+	}
+}
+
+func TestGetTelemetryFilePath_DirAlreadyExists_Succeeds(t *testing.T) {
+	tmpDir := t.TempDir()
+	// pre-create the subdir to verify MkdirAll doesn't error on existing dirs
+	os.Mkdir(filepath.Join(tmpDir, toolName), 0755)
+	setConfigDir(t, tmpDir)
+
+	_, err := getTelemetryFilePath()
+	if err != nil {
+		t.Fatalf("expected success when dir already exists, got: %v", err)
+	}
+}
+
+func TestGetTelemetryFilePath_ConfigDirError_ReturnsError(t *testing.T) {
+	setConfigDirError(t)
+
+	_, err := getTelemetryFilePath()
+	if err == nil {
+		t.Fatal("expected error when config dir unavailable, got nil")
+	}
+}
+
+// ---- Send ----
+
+func TestSend_CIEnvironment_PrintsMsgAndSkipsAnalytics(t *testing.T) {
+	t.Setenv("CI", "true")
+	mock := &mockAnalytics{}
+	setAnalytics(t, mock)
+	buf := captureStdout(t)
+
+	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+
+	if mock.event != "" {
+		t.Error("analytics.Send should not be called in CI")
+	}
+	if !strings.Contains(buf.String(), "Send telemetry") {
+		t.Errorf("expected 'Send telemetry' in output, got: %q", buf.String())
+	}
+}
+
+func TestSend_FilePathError_SkipsAnalytics(t *testing.T) {
+	t.Setenv("CI", "")
+	setConfigDirError(t)
+	mock := &mockAnalytics{}
+	setAnalytics(t, mock)
+
+	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+
+	if mock.event != "" {
+		t.Error("analytics.Send should not be called when file path resolution fails")
+	}
+}
+
+func TestSend_FirstRun_PrintsWarningAndPersistsWarnedTrue(t *testing.T) {
+	t.Setenv("CI", "")
+	tmpDir := t.TempDir()
+	setConfigDir(t, tmpDir)
+	mock := &mockAnalytics{}
+	setAnalytics(t, mock)
+	buf := captureStdout(t)
+
+	Send("token", false, config.OnlyAll, config.OutputTable, 2, 500)
+
+	if !strings.Contains(buf.String(), "anonymous usage telemetry") {
+		t.Errorf("expected telemetry warning in output, got: %q", buf.String())
+	}
+	filePath := filepath.Join(tmpDir, toolName, telemtryFileName)
+	tel, err := readTelemetry(filePath)
+	if err != nil {
+		t.Fatalf("readTelemetry: %v", err)
+	}
+	if !tel.Warned {
+		t.Error("Warned should be true after first Send")
+	}
+}
+
+func TestSend_AlreadyWarned_NoPrintNoFileUpdate(t *testing.T) {
+	t.Setenv("CI", "")
+	tmpDir := t.TempDir()
+	setConfigDir(t, tmpDir)
+
+	// pre-create the dir + file with Warned=true
+	dir := filepath.Join(tmpDir, toolName)
+	os.MkdirAll(dir, 0755)
+	writeTelemetryFile(t, filepath.Join(dir, telemtryFileName), Telemetry{UUID: "pre", Warned: true})
+
+	mock := &mockAnalytics{}
+	setAnalytics(t, mock)
+	buf := captureStdout(t)
+
+	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+
+	if strings.Contains(buf.String(), "anonymous usage telemetry") {
+		t.Error("warning should not be printed when already warned")
+	}
+}
+
+func TestSend_AnalyticsCalledWithUsageEvent(t *testing.T) {
+	t.Setenv("CI", "")
+	tmpDir := t.TempDir()
+	setConfigDir(t, tmpDir)
+	mock := &mockAnalytics{}
+	setAnalytics(t, mock)
+	captureStdout(t)
+
+	Send("token", false, config.OnlyAll, config.OutputTable, 3, 200)
+
+	if mock.event != "usage" {
+		t.Errorf("expected event 'usage', got %q", mock.event)
+	}
+	if mock.properties["repo_count"] != 3 {
+		t.Errorf("expected repo_count=3, got %v", mock.properties["repo_count"])
+	}
+	if mock.properties["project"] != toolName {
+		t.Errorf("expected project=%q, got %v", toolName, mock.properties["project"])
+	}
+}
+
+func TestSend_AnalyticsError_DoesNotPanic(t *testing.T) {
+	t.Setenv("CI", "")
+	tmpDir := t.TempDir()
+	setConfigDir(t, tmpDir)
+	mock := &mockAnalytics{err: errors.New("network error")}
+	setAnalytics(t, mock)
+	captureStdout(t)
+
+	// should complete without panic
+	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+}

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -275,8 +275,8 @@ func TestGetOrCreateTelemetry_InvalidJSON_ReturnsEmptyTelemetry(t *testing.T) {
 	os.WriteFile(path, []byte("bad json{{"), 0o644)
 
 	got, err := getOrCreateTelemetry(path)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("Error expected, but found nil")
 	}
 	if got != (Telemetry{}) {
 		t.Errorf("expected empty Telemetry on bad JSON, got %+v", got)

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -329,15 +329,11 @@ func TestSend_CIEnvironment_PrintsMsgAndSkipsAnalytics(t *testing.T) {
 	t.Setenv("CI", "true")
 	mock := &mockAnalytics{}
 	setAnalytics(t, mock)
-	buf := captureStdout(t)
 
-	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+	Send("token", false, config.OnlyAll, config.OutputTable, 1)
 
-	if mock.event != "" {
-		t.Error("analytics.Send should not be called in CI")
-	}
-	if !strings.Contains(buf.String(), "Send telemetry") {
-		t.Errorf("expected 'Send telemetry' in output, got: %q", buf.String())
+	if mock.event == "" {
+		t.Error("analytics.Send should be called in CI")
 	}
 }
 
@@ -347,7 +343,7 @@ func TestSend_FilePathError_SkipsAnalytics(t *testing.T) {
 	mock := &mockAnalytics{}
 	setAnalytics(t, mock)
 
-	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+	Send("token", false, config.OnlyAll, config.OutputTable, 1)
 
 	if mock.event != "" {
 		t.Error("analytics.Send should not be called when file path resolution fails")
@@ -362,7 +358,7 @@ func TestSend_FirstRun_PrintsWarningAndPersistsWarnedTrue(t *testing.T) {
 	setAnalytics(t, mock)
 	buf := captureStdout(t)
 
-	Send("token", false, config.OnlyAll, config.OutputTable, 2, 500)
+	Send("token", false, config.OnlyAll, config.OutputTable, 2)
 
 	if !strings.Contains(buf.String(), "anonymous usage telemetry") {
 		t.Errorf("expected telemetry warning in output, got: %q", buf.String())
@@ -391,7 +387,7 @@ func TestSend_AlreadyWarned_NoPrintNoFileUpdate(t *testing.T) {
 	setAnalytics(t, mock)
 	buf := captureStdout(t)
 
-	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+	Send("token", false, config.OnlyAll, config.OutputTable, 1)
 
 	if strings.Contains(buf.String(), "anonymous usage telemetry") {
 		t.Error("warning should not be printed when already warned")
@@ -406,7 +402,7 @@ func TestSend_AnalyticsCalledWithUsageEvent(t *testing.T) {
 	setAnalytics(t, mock)
 	captureStdout(t)
 
-	Send("token", false, config.OnlyAll, config.OutputTable, 3, 200)
+	Send("token", false, config.OnlyAll, config.OutputTable, 3)
 
 	if mock.event != "usage" {
 		t.Errorf("expected event 'usage', got %q", mock.event)
@@ -428,5 +424,5 @@ func TestSend_AnalyticsError_DoesNotPanic(t *testing.T) {
 	captureStdout(t)
 
 	// should complete without panic
-	Send("token", false, config.OnlyAll, config.OutputTable, 1, 100)
+	Send("token", false, config.OnlyAll, config.OutputTable, 1)
 }

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -2,6 +2,7 @@ version = 1
 
 # When true log file will appear in ~/.config/reposcan/logs/
 debug = false
+no-telemetry = false
 
 roots = [
     "/home/mabd/"


### PR DESCRIPTION
# Pull Request

## Description

Send anonymous telemetry usage only if user allows it. When running in CI environment, no consent will be shown, but telemetry can still be disabled with `--no-telemetry` cli-flag


## Changes Made

<!-- List the specific changes you made -->

- added `no-telemetry` cli-flag
- added `no-telemetry` to repo `config.toml`
- save `telemetry.json` to `${USER_CONFIG_DIR}/reposcan/` 
- send telemetry warning only once

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally with example workflows
- [x] Added new tests (if applicable)
- [x] Tested with different `filters`, `output`, etc...


## Checklist

- [x] I have starred the repository
- [x] My code follows the project's code style
- [x] I have updated the documentation (README, cli-flags, etc...)
- [x] My changes generate no new warnings
- [x] I have tested my changes in a real workflow
- [x] All tests pass locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces opt-in anonymous telemetry via Mixpanel, guarded by a `--no-telemetry` CLI flag and a `telemetry.json` consent file stored in the user config directory. A one-time notice is printed on first run; subsequent runs skip the notice.

- **New `internal/telemetry` package**: handles UUID generation, consent-file persistence, and analytics dispatch; variables are injected for testability.
- **`--no-telemetry` flag**: wired through `Config.NoTelemetry`, read from both `config.toml` and CLI flags, and checked in `run()` before dispatching telemetry.
- **CI handling**: when the `CI` env var is set, telemetry is sent immediately without consulting the consent file — bypassing the user-opt-in flow described in the PR.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix: `writeTelemetry` return values should be checked at both call sites before shipping.

The core telemetry flow works correctly for the happy path. The one concrete defect is that `writeTelemetry` errors are silently discarded in both `getOrCreateTelemetry` (UUID persistence) and `Send` (Warned-state persistence). On any filesystem where the config dir is not writable, every run generates a fresh ephemeral UUID and reprints the consent notice, corrupting analytics data and degrading user experience. The rest of the integration is straightforward and correct.

`internal/telemetry/telemetry.go` — specifically the two `writeTelemetry` call sites that drop their error returns.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/telemetry/telemetry.go | New telemetry package — `writeTelemetry` return values silently discarded in two places, causing UUID and Warned-state loss on write failures. |
| internal/telemetry/telemetry_test.go | Good breadth of unit tests; test name `TestSend_CIEnvironment_PrintsMsgAndSkipsAnalytics` contradicts its assertion. |
| cmd/reposcan/rootCmd.go | Adds `no-telemetry` flag reading and gates `telemetry.Send` behind `configs.NoTelemetry`; logic is correct. |
| cmd/reposcan/flags_read_test.go | Registers and parses the new `no-telemetry` flag in tests; assertion only tests the default value. |
| internal/config/types.go | Adds `NoTelemetry bool` field with correct TOML tag; no issues. |
| cmd/reposcan/main.go | Registers `--no-telemetry` as a `BoolP` flag; matches pattern of existing flags, no issues. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[run configs] --> B{NoTelemetry?}
    B -- yes --> C[skip telemetry]
    B -- no --> D{CI env set?}
    D -- yes --> E[sendTelemetry directly]
    D -- no --> F[getTelemetryFilePath]
    F --> G{error?}
    G -- yes --> H[log error, return]
    G -- no --> I[getOrCreateTelemetry]
    I --> J{file exists?}
    J -- no --> K[create new UUID + write file]
    J -- yes --> L[read telemetry.json]
    K --> M{Warned?}
    L --> M
    M -- no --> N[print consent notice, set Warned=true, write file]
    M -- yes --> O[skip notice]
    N --> E
    O --> E
    E --> P[analyticsService.Send usage event]
```
</details>

<sub>Reviews (4): Last reviewed commit: ["send ci to analytics"](https://github.com/mabd-dev/reposcan/commit/2501f679493abe65a422fd3eb431079aaacadc63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33273455)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->