### PR TITLE
fix(tui): handle empty state in interactive mode (#41)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mabd-dev/reposcan
 
-go 1.24.6
+go 1.24
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mabd-dev/reposcan
 
-go 1.24
+go 1.24.6
 
 require (
 	github.com/bmatcuk/doublestar/v4 v4.9.1

--- a/internal/render/tui/repostable/main.go
+++ b/internal/render/tui/repostable/main.go
@@ -23,6 +23,7 @@ func New(
 		report:        report,
 		filteredRepos: report.RepoStates,
 		filterQuery:   "",
+		totalRepos:    report.TotalRepos,
 	}
 
 	cols := createColumns(width)
@@ -52,6 +53,7 @@ func (rt Model) Init() tea.Cmd { return nil }
 
 func (m *Model) SetReport(report report.ScanReport) {
 	m.report = report
+	m.totalRepos = report.TotalRepos
 	m.Filter(m.filterQuery)
 }
 

--- a/internal/render/tui/repostable/main.go
+++ b/internal/render/tui/repostable/main.go
@@ -38,11 +38,6 @@ func New(
 	km := table.DefaultKeyMap()
 	setKeymaps(km)
 
-	// if no repos, show an empty placeholder row so the table renders nicely
-	if len(rows) == 0 {
-		t.SetRows([]table.Row{{"", "", ""}})
-	}
-
 	t.SetStyles(table.Styles{
 		Header:   model.theme.Styles.TableHeader,
 		Selected: model.theme.Styles.TableSelectedRow,

--- a/internal/render/tui/repostable/types.go
+++ b/internal/render/tui/repostable/types.go
@@ -16,4 +16,5 @@ type Model struct {
 	report        report.ScanReport
 	filteredRepos []report.RepoState
 	filterQuery   string
+	totalRepos    int
 }

--- a/internal/render/tui/repostable/update.go
+++ b/internal/render/tui/repostable/update.go
@@ -3,13 +3,13 @@ package repostable
 import tea "github.com/charmbracelet/bubbletea"
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
-	// Guard: skip keyboard navigation when there are no repos to display.
-	if m.ReposCount() == 0 {
-		return m, nil
-	}
-
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// Guard: skip keyboard navigation when there are no repos to display.
+		if m.ReposCount() == 0 {
+			return m, nil
+		}
+
 		switch msg.String() {
 		case "j":
 			if m.tbl.Cursor() == len(m.tbl.Rows())-1 {

--- a/internal/render/tui/repostable/update.go
+++ b/internal/render/tui/repostable/update.go
@@ -3,6 +3,11 @@ package repostable
 import tea "github.com/charmbracelet/bubbletea"
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
+	// Guard: skip keyboard navigation when there are no repos to display.
+	if m.ReposCount() == 0 {
+		return m, nil
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {

--- a/internal/render/tui/repostable/view.go
+++ b/internal/render/tui/repostable/view.go
@@ -26,7 +26,13 @@ func (m Model) View() string {
 
 // renderEmptyState returns a styled, centered message when the repo list is empty.
 func (m Model) renderEmptyState() string {
-	msg := "✨ No repositories found — your workspace is spotless!"
+	var msg string
+	if m.totalRepos == 0 {
+		msg = "🔍 No repositories found in the scanned directory."
+	} else {
+		msg = "✨ All repositories are clean — your workspace is spotless!"
+	}
+
 	styled := m.theme.Styles.Base.
 		Foreground(m.theme.Colors.Accent).
 		Render(msg)

--- a/internal/render/tui/repostable/view.go
+++ b/internal/render/tui/repostable/view.go
@@ -8,6 +8,12 @@ import (
 )
 
 func (m Model) View() string {
+	// When no repos match the current filter, show a friendly empty-state
+	// message instead of an empty table. See issue #41.
+	if m.ReposCount() == 0 {
+		return m.renderEmptyState()
+	}
+
 	body := m.theme.Styles.
 		BoxFor(m.tbl.Focused()).
 		Render(m.tbl.View())
@@ -16,6 +22,28 @@ func (m Model) View() string {
 	body = m.addSectionTitle(body)
 
 	return body
+}
+
+// renderEmptyState returns a styled, centered message when the repo list is empty.
+func (m Model) renderEmptyState() string {
+	msg := "✨ No repositories found — your workspace is spotless!"
+	styled := m.theme.Styles.Base.
+		Foreground(m.theme.Colors.Accent).
+		Render(msg)
+
+	// Center the message horizontally and vertically inside the box area.
+	// Use the table height as the target so the layout stays consistent.
+	centered := lipgloss.Place(
+		m.width-4,  // account for box borders + padding
+		m.height-2, // account for box borders
+		lipgloss.Center,
+		lipgloss.Center,
+		styled,
+	)
+
+	return m.theme.Styles.
+		BoxFor(m.tbl.Focused()).
+		Render(centered)
 }
 
 func (m Model) addIndicator(body string) string {

--- a/internal/render/tui/repostable/view.go
+++ b/internal/render/tui/repostable/view.go
@@ -27,9 +27,12 @@ func (m Model) View() string {
 // renderEmptyState returns a styled, centered message when the repo list is empty.
 func (m Model) renderEmptyState() string {
 	var msg string
-	if m.totalRepos == 0 {
+	switch {
+	case m.totalRepos == 0:
 		msg = "🔍 No repositories found in the scanned directory."
-	} else {
+	case m.filterQuery != "":
+		msg = "🔎 No repositories match your search."
+	default:
 		msg = "✨ All repositories are clean — your workspace is spotless!"
 	}
 

--- a/internal/render/tui/repostable/view_test.go
+++ b/internal/render/tui/repostable/view_test.go
@@ -34,6 +34,39 @@ func stubTheme() theme.Theme {
 	return theme.Theme{Colors: colors, Styles: styles}
 }
 
+func TestView_EmptyState_FilterNoMatches(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{
+			RepoStates: []report.RepoState{
+				{Repo: "alpha", Branch: "main", ID: "alpha"},
+				{Repo: "beta", Branch: "main", ID: "beta"},
+			},
+			TotalRepos: 2,
+		},
+		80,
+		20,
+	)
+
+	// Apply a text filter that matches nothing.
+	m.Filter("zzzz")
+
+	view := m.View()
+
+	if !strings.Contains(view, "No repositories match your search") {
+		t.Errorf("expected 'no match' message when filter returns empty, got:\n%s", view)
+	}
+
+	if !strings.Contains(view, "🔎") {
+		t.Errorf("expected search emoji, got:\n%s", view)
+	}
+
+	// Make sure we do NOT show the misleading 'all clean' message.
+	if strings.Contains(view, "spotless") {
+		t.Errorf("expected NO 'spotless' message when filter is active, got:\n%s", view)
+	}
+}
+
 func TestView_EmptyState_NoReposFound(t *testing.T) {
 	m := New(
 		stubTheme(),

--- a/internal/render/tui/repostable/view_test.go
+++ b/internal/render/tui/repostable/view_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/bubbles/table"
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mabd-dev/reposcan/internal/theme"
 	"github.com/mabd-dev/reposcan/pkg/report"
@@ -12,10 +14,10 @@ import (
 // stubTheme returns a minimal theme sufficient for view tests.
 func stubTheme() theme.Theme {
 	colors := theme.LipglossScheme{
-		Foreground: lipgloss.Color("#ffffff"),
-		Accent:     lipgloss.Color("#00ff00"),
-		Border:     lipgloss.Color("#444444"),
-		BorderActive: lipgloss.Color("#00ff00"),
+		Foreground:     lipgloss.Color("#ffffff"),
+		Accent:         lipgloss.Color("#00ff00"),
+		Border:         lipgloss.Color("#444444"),
+		BorderActive:   lipgloss.Color("#00ff00"),
 	}
 	styles := theme.Styles{
 		Base: lipgloss.NewStyle(),
@@ -26,33 +28,64 @@ func stubTheme() theme.Theme {
 		BoxMuted: lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(colors.Border),
+		TableHeader:    lipgloss.NewStyle(),
+		TableRow:       lipgloss.NewStyle(),
+		TableSelectedRow: lipgloss.NewStyle(),
 	}
 	return theme.Theme{Colors: colors, Styles: styles}
 }
 
-func TestView_EmptyState_RendersMessage(t *testing.T) {
+func TestView_EmptyState_NoReposFound(t *testing.T) {
 	m := New(
 		stubTheme(),
-		report.ScanReport{RepoStates: []report.RepoState{}},
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 0,
+		},
 		80, // width
 		20, // height
 	)
 
 	view := m.View()
 
-	if !strings.Contains(view, "No repositories found") {
-		t.Errorf("expected empty-state message, got:\n%s", view)
+	if !strings.Contains(view, "No repositories found in the scanned directory") {
+		t.Errorf("expected 'no repos found' message, got:\n%s", view)
+	}
+
+	if !strings.Contains(view, "🔍") {
+		t.Errorf("expected magnifying-glass emoji, got:\n%s", view)
+	}
+}
+
+func TestView_EmptyState_AllClean(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 3, // 3 repos found but all clean / filtered out
+		},
+		80,
+		20,
+	)
+
+	view := m.View()
+
+	if !strings.Contains(view, "All repositories are clean") {
+		t.Errorf("expected 'all clean' message, got:\n%s", view)
 	}
 
 	if !strings.Contains(view, "✨") {
-		t.Errorf("expected sparkle emoji in empty-state, got:\n%s", view)
+		t.Errorf("expected sparkle emoji, got:\n%s", view)
 	}
 }
 
 func TestView_EmptyState_NoTablePlaceholder(t *testing.T) {
 	m := New(
 		stubTheme(),
-		report.ScanReport{RepoStates: []report.RepoState{}},
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 0,
+		},
 		80,
 		20,
 	)
@@ -73,6 +106,7 @@ func TestView_WithRepos_RendersTable(t *testing.T) {
 			RepoStates: []report.RepoState{
 				{Repo: "foo", Branch: "main", ID: "foo"},
 			},
+			TotalRepos: 1,
 		},
 		80,
 		20,
@@ -92,22 +126,48 @@ func TestView_WithRepos_RendersTable(t *testing.T) {
 func TestUpdate_EmptyState_DoesNotCrash(t *testing.T) {
 	m := New(
 		stubTheme(),
-		report.ScanReport{RepoStates: []report.RepoState{}},
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 0,
+		},
 		80,
 		20,
 	)
 
 	// Simulate a keypress when there are no repos — should not panic.
-	_, cmd := m.Update(nil)
+	keyMsg := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'j'}}
+	_, cmd := m.Update(keyMsg)
 	if cmd != nil {
-		t.Error("expected nil command for empty-state update")
+		t.Error("expected nil command for empty-state key update")
+	}
+}
+
+func TestUpdate_EmptyState_WindowSize_PassesThrough(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 0,
+		},
+		80,
+		20,
+	)
+
+	// Window-size messages should still reach the underlying table.
+	wsMsg := tea.WindowSizeMsg{Width: 100, Height: 30}
+	_, cmd := m.Update(wsMsg)
+	if cmd != nil {
+		t.Error("expected nil command for window-size in empty state")
 	}
 }
 
 func TestReposCount_Empty_ReturnsZero(t *testing.T) {
 	m := New(
 		stubTheme(),
-		report.ScanReport{RepoStates: []report.RepoState{}},
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 0,
+		},
 		80,
 		20,
 	)
@@ -125,6 +185,7 @@ func TestReposCount_NonEmpty_ReturnsCount(t *testing.T) {
 				{Repo: "a", ID: "a"},
 				{Repo: "b", ID: "b"},
 			},
+			TotalRepos: 2,
 		},
 		80,
 		20,
@@ -132,5 +193,28 @@ func TestReposCount_NonEmpty_ReturnsCount(t *testing.T) {
 
 	if m.ReposCount() != 2 {
 		t.Errorf("expected 2 repos, got %d", m.ReposCount())
+	}
+}
+
+func TestSetReport_UpdatesTotalRepos(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{
+			RepoStates: []report.RepoState{},
+			TotalRepos: 0,
+		},
+		80,
+		20,
+	)
+
+	m.SetReport(report.ScanReport{
+		RepoStates: []report.RepoState{
+			{Repo: "x", ID: "x"},
+		},
+		TotalRepos: 5,
+	})
+
+	if m.totalRepos != 5 {
+		t.Errorf("expected totalRepos=5 after SetReport, got %d", m.totalRepos)
 	}
 }

--- a/internal/render/tui/repostable/view_test.go
+++ b/internal/render/tui/repostable/view_test.go
@@ -1,0 +1,136 @@
+package repostable
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mabd-dev/reposcan/internal/theme"
+	"github.com/mabd-dev/reposcan/pkg/report"
+)
+
+// stubTheme returns a minimal theme sufficient for view tests.
+func stubTheme() theme.Theme {
+	colors := theme.LipglossScheme{
+		Foreground: lipgloss.Color("#ffffff"),
+		Accent:     lipgloss.Color("#00ff00"),
+		Border:     lipgloss.Color("#444444"),
+		BorderActive: lipgloss.Color("#00ff00"),
+	}
+	styles := theme.Styles{
+		Base: lipgloss.NewStyle(),
+		Muted: lipgloss.NewStyle(),
+		Box: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colors.BorderActive),
+		BoxMuted: lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colors.Border),
+	}
+	return theme.Theme{Colors: colors, Styles: styles}
+}
+
+func TestView_EmptyState_RendersMessage(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{RepoStates: []report.RepoState{}},
+		80, // width
+		20, // height
+	)
+
+	view := m.View()
+
+	if !strings.Contains(view, "No repositories found") {
+		t.Errorf("expected empty-state message, got:\n%s", view)
+	}
+
+	if !strings.Contains(view, "✨") {
+		t.Errorf("expected sparkle emoji in empty-state, got:\n%s", view)
+	}
+}
+
+func TestView_EmptyState_NoTablePlaceholder(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{RepoStates: []report.RepoState{}},
+		80,
+		20,
+	)
+
+	view := m.View()
+
+	// The old code used to inject an empty table row {{"", "", ""}}.
+	// With the fix, the table should not appear at all.
+	if strings.Contains(view, "Repo") && strings.Contains(view, "Branch") && strings.Contains(view, "State") {
+		t.Errorf("expected NO table headers in empty state, got:\n%s", view)
+	}
+}
+
+func TestView_WithRepos_RendersTable(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{
+			RepoStates: []report.RepoState{
+				{Repo: "foo", Branch: "main", ID: "foo"},
+			},
+		},
+		80,
+		20,
+	)
+
+	view := m.View()
+
+	if !strings.Contains(view, "foo") {
+		t.Errorf("expected repo name 'foo' in table view, got:\n%s", view)
+	}
+
+	if !strings.Contains(view, "Repo") {
+		t.Errorf("expected table header 'Repo' in table view, got:\n%s", view)
+	}
+}
+
+func TestUpdate_EmptyState_DoesNotCrash(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{RepoStates: []report.RepoState{}},
+		80,
+		20,
+	)
+
+	// Simulate a keypress when there are no repos — should not panic.
+	_, cmd := m.Update(nil)
+	if cmd != nil {
+		t.Error("expected nil command for empty-state update")
+	}
+}
+
+func TestReposCount_Empty_ReturnsZero(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{RepoStates: []report.RepoState{}},
+		80,
+		20,
+	)
+
+	if m.ReposCount() != 0 {
+		t.Errorf("expected 0 repos, got %d", m.ReposCount())
+	}
+}
+
+func TestReposCount_NonEmpty_ReturnsCount(t *testing.T) {
+	m := New(
+		stubTheme(),
+		report.ScanReport{
+			RepoStates: []report.RepoState{
+				{Repo: "a", ID: "a"},
+				{Repo: "b", ID: "b"},
+			},
+		},
+		80,
+		20,
+	)
+
+	if m.ReposCount() != 2 {
+		t.Errorf("expected 2 repos, got %d", m.ReposCount())
+	}
+}

--- a/internal/render/tui/repostable/view_test.go
+++ b/internal/render/tui/repostable/view_test.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/charmbracelet/bubbles/table"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/mabd-dev/reposcan/internal/theme"

--- a/internal/scanGenerator.go
+++ b/internal/scanGenerator.go
@@ -35,6 +35,7 @@ func GenerateScanReport(
 		Version:     configs.Version,
 		GeneratedAt: time.Now(),
 		RepoStates:  repoStates,
+		TotalRepos:  len(allRepoStates),
 		Warnings:    reportWarnings,
 	}
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -28,6 +28,7 @@ type RepoState struct {
 type ScanReport struct {
 	Version     int         `json:"version"`
 	RepoStates  []RepoState `json:"repoStates"`
+	TotalRepos  int         `json:"totalRepos"`
 	GeneratedAt time.Time   `json:"generatedAt"`
 	Warnings    []string    `json:"warnings"`
 }


### PR DESCRIPTION
## Summary

Fixes the empty-table UX issue reported in #41.

## Problem

When  is run in interactive (TUI) mode and no repositories match the current filter (or all repos are clean), the table area renders as a near-empty box with a placeholder row of blank strings. This is visually broken and confusing for first-time users.

## Changes

1. **Empty-state view** ()
   - Added  that returns a centered, styled message:
     > ✨ No repositories found — your workspace is spotless!
   -  now branches: if  it shows the empty-state; otherwise it renders the normal table.

2. **Removed placeholder workaround** ()
   - The old code injected an empty  when no repos existed. This is no longer needed because the table is not rendered at all in the empty case.

3. **Keyboard guard** ()
   - Added an early return when  so that cursor navigation (j/k) does not attempt to move on a zero-row table.

4. **Tests** ()
   -  — verifies the sparkle emoji and message text are present.
   -  — asserts that table headers (Repo / Branch / State) are absent when empty.
   -  — sanity check that normal repos still render the table.
   -  — ensures keyboard events are safely ignored when empty.
   -  /  — basic count correctness.

## Verification

All 6 new tests pass:



## Related

- Closes #41

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the empty-table UX bug (#41) in TUI interactive mode by replacing the blank placeholder-row workaround with a proper empty-state view, adding a keyboard guard for zero-row navigation, and surfacing `TotalRepos` through the scan pipeline so the UI can distinguish \"no repos found\" from \"all repos are clean\".

- **`pkg/report/report.go` + `scanGenerator.go`**: adds `TotalRepos` (pre-filter count) to `ScanReport` and populates it as `len(allRepoStates)`.
- **`repostable/view.go`**: `View()` short-circuits to `renderEmptyState()` when the filtered list is empty, showing one of two centered messages inside the existing box chrome.
- **`repostable/update.go`**: keyboard guard placed inside `case tea.KeyMsg` so `j`/`k` navigation is blocked on an empty list while other message types (window-size, etc.) still reach the underlying table.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one message-correctness fix: when the user's live text filter returns zero matches, the empty-state view shows 'All repositories are clean' even though the repos may be dirty.

The core guard and empty-state rendering work correctly. The one defect is in renderEmptyState: the branch that picks between 'no repos found' and 'all clean' checks only totalRepos, so it always displays the 'spotless workspace' message whenever totalRepos > 0 — including when a non-empty TUI text filter simply matched nothing. This gives the user actively wrong feedback about their repository state.

internal/render/tui/repostable/view.go — the renderEmptyState message-selection logic needs a third branch for the text-filter-returns-zero case.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/render/tui/repostable/view.go | Adds empty-state rendering with two-branch message logic; the branch discriminant (totalRepos == 0) does not distinguish between 'all repos are clean' and 'text filter matched nothing', producing a misleading 'spotless' message when the user's live search query returns zero results. |
| internal/render/tui/repostable/update.go | Keyboard guard correctly scoped inside the tea.KeyMsg case; non-keyboard messages (WindowSizeMsg, etc.) pass through to the underlying table as expected. |
| internal/render/tui/repostable/main.go | Initializes and updates totalRepos from report in both New() and SetReport(); removes the empty placeholder-row workaround cleanly. |
| internal/render/tui/repostable/view_test.go | Good coverage of the new empty-state and keyboard-guard paths; missing a test for the case where a non-empty text filter produces zero results (the scenario where the P1 message bug manifests). |
| internal/scanGenerator.go | Correctly populates TotalRepos as len(allRepoStates) — the count of all repos before the OnlyFilter is applied. |
| pkg/report/report.go | Adds TotalRepos int field to ScanReport with JSON serialization; no issues. |

</details>



<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tea.Msg arrives at Update] --> B{msg type?}
    B -- tea.KeyMsg --> C{ReposCount == 0?}
    C -- yes --> D[return m, nil skip navigation]
    C -- no --> E[handle j/k or pass to tbl.Update]
    B -- other msg --> F[pass to tbl.Update]
    G[View called] --> H{ReposCount == 0?}
    H -- yes --> I{totalRepos == 0?}
    I -- yes --> J[No repos found message]
    I -- no --> K[All repos clean message]
    H -- no --> L[render table + indicator + title]
```
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `internal/render/tui/repostable/view.go`, line 49-52 ([link](https://github.com/mabd-dev/reposcan/blob/f2be0e1732c06179042af1f84baa72380e7e00a3/internal/render/tui/repostable/view.go#L49-L52)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Dead branch in `addIndicator` after empty-state short-circuit**

   `View()` now returns `renderEmptyState()` before ever calling `addIndicator`, so the `if m.ReposCount() == 0` block (which would have rendered `"0/0"`) is unreachable. This also means the empty-state box skips both the `"repos"` section title and the `"0/0"` indicator overlays that the non-empty path produces, so the two states have visually inconsistent chrome. Consider either calling `addIndicator` / `addSectionTitle` inside `renderEmptyState`, or removing the dead zero-count branch from `addIndicator`.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["feat: differentiate empty states and add..."](https://github.com/mabd-dev/reposcan/commit/db0ccb94625da30236db1525068433814a238f88) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34101118)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->