### PR TITLE
Feat/support worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
-- feat/supportWorktree by @mabd-dev
+- feat/supportWorktree: Detect git worktrees and submodules (`.git` file with `gitdir:` pointer) during repo scan by @mabd-dev in [#43](https://github.com/mabd-dev/reposcan/pull/43)
 
 ## [1.3.8] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changes
+
+- feat/supportWorktree by @mabd-dev
 
 ## [1.3.8] - 2026-05-21
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Each step overrides the one before it
 - [x] Export Report to json file
 - [x] Support dirignore
 - [x] Worker pool for speed
-- [ ] Support git worktrees
+- [x] Support git worktrees
 - [ ] Perform git push/pull/fetch on repos
 - [ ] Show branches with their states on each repo
 

--- a/internal/scan/scan.go
+++ b/internal/scan/scan.go
@@ -59,14 +59,15 @@ func isGitRepo(path string) bool {
 	if file, err := os.Lstat(gitPath); err == nil {
 		if file.IsDir() {
 			return true
-		} else {
-			// git worktrees has gitdir: folder
-			b, err := os.ReadFile(path)
-			if err != nil {
-				return false
-			}
-			return strings.Contains(string(b), "gitdir:")
 		}
+
+		// git worktrees use a .git file containing "gitdir: ..."
+		b, err := os.ReadFile(gitPath)
+		if err != nil {
+			return false
+		}
+
+		return strings.Contains(string(b), "gitdir:")
 	}
 	return false
 }

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -61,7 +61,7 @@ func TestFindGitRepos_RespectsDirIgnore(t *testing.T) {
 func TestFindGitRepos_GitWorktree(t *testing.T) {
 	root := t.TempDir()
 
-	worktree := filepath.Join(root, "workree1")
+	worktree := filepath.Join(root, "worktree1")
 	makeDir(t, worktree)
 
 	gitFilepath := filepath.Join(worktree, ".git")

--- a/internal/scan/scan_test.go
+++ b/internal/scan/scan_test.go
@@ -57,3 +57,26 @@ func TestFindGitRepos_RespectsDirIgnore(t *testing.T) {
 		t.Fatalf("expected only %s, got %v", repo1, repos)
 	}
 }
+
+func TestFindGitRepos_GitWorktree(t *testing.T) {
+	root := t.TempDir()
+
+	worktree := filepath.Join(root, "workree1")
+	makeDir(t, worktree)
+
+	gitFilepath := filepath.Join(worktree, ".git")
+
+	gitFileContent := []byte("gitdir: /Users/someone/worktreeRepo.git/worktrees/worktree1\n")
+	err := os.WriteFile(gitFilepath, gitFileContent, 0o644)
+
+	if err != nil {
+		t.Fatalf("error writing to file, error=%v", err.Error())
+	}
+
+	patterns := []string{"**/node_modules/**", "/ignored/**"}
+	repos, _ := FindGitRepos([]string{root}, patterns)
+
+	if len(repos) != 1 || repos[0] != worktree {
+		t.Fatalf("expected only %s, got %v", worktree, repos)
+	}
+}


### PR DESCRIPTION
# Pull Request

## Description

Detect worktree and submodules during scan

## Changes Made

- update `isGitRepo` function to also detect git worktrees
- Check for repo with .git file and `gitdir:` content

## Testing

- [x] Tested locally with example workflows
- [x] Added new tests (if applicable)
- [x] Tested with different `filters`, `output`, etc...

## Checklist

- [x] I have starred the repository
- [x] My code follows the project's code style
- [x] I have updated the documentation (README, cli-flags, etc...)
- [x] My changes generate no new warnings
- [x] I have tested my changes in a real workflow
- [x] All tests pass locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a pre-existing bug in `isGitRepo` where `os.ReadFile(path)` was reading the directory path instead of the `.git` file path, making worktree/submodule detection always fail. The fix correctly reads `gitPath` and adds a test to cover the worktree case.

- **`internal/scan/scan.go`**: Corrects `os.ReadFile(path)` → `os.ReadFile(gitPath)` so the `.git` file content is actually read when checking for the `gitdir:` pointer.
- **`internal/scan/scan_test.go`**: Adds `TestFindGitRepos_GitWorktree` to verify a directory with a `.git` file containing `gitdir:` is recognised as a repo.
- **`README.md` / `CHANGELOG.md`**: Marks the worktree feature complete and records the change.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the core logic change is a straightforward bug fix that correctly reads the `.git` file, and the new test exercises the happy path.

The core bug fix correctly changes `os.ReadFile(path)` to `os.ReadFile(gitPath)`, resolving a silent failure where worktree detection never worked. Only cosmetic issues remain: a typo in a test directory name and a non-descriptive changelog entry.

`internal/scan/scan_test.go` has the typo in the worktree directory name; `CHANGELOG.md` has a non-descriptive entry — both are minor.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/scan/scan.go | Bug fix: `os.ReadFile` was incorrectly called with the directory path (`path`) instead of the `.git` file path (`gitPath`). Now correctly reads the `.git` file to detect `gitdir:` for worktrees and submodules. |
| internal/scan/scan_test.go | New test for worktree detection works correctly but contains a typo (`"workree1"` instead of `"worktree1"`) in the temporary directory name. |
| README.md | Marks "Support git worktrees" TODO item as complete. No functional changes. |
| CHANGELOG.md | Adds an Unreleased entry, but uses the branch/PR name as the description instead of a human-readable changelog entry. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[FindGitRepos: walk directory] --> B{d.IsDir?}
    B -- No --> C[skip file]
    B -- Yes --> D{isGitRepo path}
    D --> E[Build gitPath = path/.git]
    E --> F{os.Lstat gitPath}
    F -- error --> G[return false]
    F -- ok --> H{file.IsDir?}
    H -- Yes --> I[return true\nnormal repo]
    H -- No --> J[os.ReadFile gitPath]
    J -- error --> K[return false]
    J -- ok --> L{contains 'gitdir:'}
    L -- Yes --> M[return true\nworktree / submodule]
    L -- No --> N[return false]
    I --> O[append path, SkipDir]
    M --> O
```
</details>

<sub>Reviews (1): Last reviewed commit: ["added unit test"](https://github.com/mabd-dev/reposcan/commit/8c708437a41bc8f1119621e8239bcaab2bd65391) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34148690)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->