### PR TITLE
feat: detect stashed changes as a repo state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- feat/detect-stashes: Detect stashed changes as a repo state; adds `stash` filter and opt-in `count_stash_as_dirty` config by @nilp0inter in [#47](https://github.com/mabd-dev/reposcan/pull/47)
 - feat/supportWorktree: Detect git worktrees and submodules (`.git` file with `gitdir:` pointer) during repo scan by @mabd-dev in [#43](https://github.com/mabd-dev/reposcan/pull/43)
 
 ## [1.3.8] - 2026-05-21

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ reposcan -r ~/Code -r ~/work
 Common flags
 ```sh
 -d, --dirIgnore stringArray     # (default [$HOME])
--f, --filter string             # Repository filter: all|dirty|uncommitted|unpushed|unpulled (default "dirty")
+-f, --filter string             # Repository filter: all|dirty|uncommitted|unpushed|unpulled|stash (default "dirty")
 -h, --help                      # help for reposcan
     --json-output-path string   # Write scan report JSON files to this directory (optional)
 -w, --max-workers int           # Number of concurrent git checks (default 8)
@@ -136,6 +136,10 @@ roots = ["~/Code", "~/work"]
 
 only = "dirty"
 
+# Count repos whose only local state is stashed work as dirty (default false).
+# Only affects `only = "dirty"`; `only = "stash"` is unaffected.
+count_stash_as_dirty = false
+
 # Skip these directories (glob patterns)
 dirIgnore = [
   "/node_modules/",
@@ -165,6 +169,7 @@ Each step overrides the one before it
 ## 🛣 Roadmap
 - [x] Scan filesystem for repos
 - [x] Detect uncommitted files, unpushed commits and unpulled commits
+- [x] Detect stashed changes
 - [x] Stdout Ouput in 3 formats: json, interactive, none
 - [x] Read user customizable `config.toml` file
 - [x] Export Report to json file

--- a/cmd/reposcan/main.go
+++ b/cmd/reposcan/main.go
@@ -35,7 +35,7 @@ func init() {
 	RootCmd.PersistentFlags().StringArrayP("root", "r", configs.Roots, "Root directory to scan (repeatable). Defaults to $HOME if unset in config.")
 	RootCmd.PersistentFlags().StringArrayP("dirIgnore", "d", []string{}, "Glob patterns to ignore during scan (repeatable)")
 	RootCmd.PersistentFlags().StringP("output", "o", string(configs.Output.Type), "Output format: json|interactive|none")
-	RootCmd.PersistentFlags().StringP("filter", "f", string(configs.Only), "Repository filter: all|dirty|uncommitted|unpushed|unpulled")
+	RootCmd.PersistentFlags().StringP("filter", "f", string(configs.Only), "Repository filter: all|dirty|uncommitted|unpushed|unpulled|stash")
 	RootCmd.PersistentFlags().String("json-output-path", configs.Output.JSONPath, "Write scan report JSON files to this directory (optional)")
 	RootCmd.PersistentFlags().IntP("max-workers", "w", configs.MaxWorkers, "Number of concurrent git checks")
 	RootCmd.PersistentFlags().BoolP("debug", "", configs.Debug, "Enable/Disable debug mode")

--- a/cmd/reposcan/rootCmd.go
+++ b/cmd/reposcan/rootCmd.go
@@ -68,7 +68,7 @@ var RootCmd = &cobra.Command{
 //   - root (-r)					: repeatable directory roots to scan
 //   - dirIgnore (-d)       		: repeatable glob patterns to ignore during scan
 //   - output (-o)          		: output format: json|interactive|none
-//   - filter (-f)          		: repository filter: all|dirty|uncommitted|unpushed|unpulled
+//   - filter (-f)          		: repository filter: all|dirty|uncommitted|unpushed|unpulled|stash
 //   - json-output-path     		: directory to write JSON report files
 //   - max-workers (-w)     		: number of concurrent git checks
 //   - debug (--debug)      		: enable/disable debug mode

--- a/docs/cli-flags.md
+++ b/docs/cli-flags.md
@@ -25,18 +25,26 @@ This document explains each CLI flag, its equivalent `config.toml` field, what i
       ```
 
 - `-f, --filter TYPE`
-  - Config: `only = "dirty" | "all" | "uncommitted" | "unpushed" | "unpulled"`
+  - Config: `only = "dirty" | "all" | "uncommitted" | "unpushed" | "unpulled" | "stash"`
   - Description: Filter which repositories to include in the report.
-    - `dirty`: any of uncommitted files, ahead, or behind.
+    - `dirty`: any of uncommitted files, ahead, or behind (and stashes when `count_stash_as_dirty = true`).
     - `uncommitted`: only repos with uncommitted files.
     - `unpushed`: only repos with commits ahead of upstream.
     - `unpulled`: only repos with commits behind upstream.
+    - `stash`: only repos with stash entries (independent of `count_stash_as_dirty`).
     - `all`: all repos discovered.
   - Examples:
     - `reposcan --filter dirty`
     - `reposcan --filter uncommitted`
     - `reposcan --filter unpushed`
     - `reposcan --filter unpulled`
+    - `reposcan --filter stash`
+
+- `count_stash_as_dirty` (config only, no CLI flag)
+  - Config: `count_stash_as_dirty = false` (default)
+  - Description: When `true`, repositories whose only local state is stashed work
+    are treated as dirty for `--filter dirty` and the dirty total. The
+    `--filter stash` value is unaffected by this setting.
 
 - `-o, --output TYPE`
   - Config: `output.type = "json" | "interactive" | "none"`

--- a/internal/config/onlyFilter.go
+++ b/internal/config/onlyFilter.go
@@ -22,12 +22,14 @@ const (
     OnlyUnpushed    = "unpushed"
     // OnlyUnpulled includes repositories with upstream commits not yet pulled.
     OnlyUnpulled    = "unpulled"
+    // OnlyStash includes repositories that have stash entries.
+    OnlyStash       = "stash"
 )
 
 // IsValid reports whether f is a recognized OnlyFilter value.
 func (f OnlyFilter) IsValid() bool {
     switch f {
-    case OnlyAll, OnlyDirty, OnlyUncommitted, OnlyUnpushed, OnlyUnpulled:
+    case OnlyAll, OnlyDirty, OnlyUncommitted, OnlyUnpushed, OnlyUnpulled, OnlyStash:
         return true
     }
     return false
@@ -49,6 +51,8 @@ func CreateOnlyFilter(s string) (OnlyFilter, error) {
         return OnlyUnpushed, nil
     case string(OnlyUnpulled):
         return OnlyUnpulled, nil
+    case string(OnlyStash):
+        return OnlyStash, nil
     }
 
     return OnlyAll, errors.New(s + " is not valid only filter")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -11,6 +11,11 @@ type Config struct {
 
 	Output Output `toml:"output"`
 
+	// CountStashAsDirty, when true, makes repos with only stashed work count as
+	// dirty for IsDirty-based filtering (--filter dirty) and the dirty total.
+	// The --filter stash value is unaffected by this setting.
+	CountStashAsDirty bool `toml:"count_stash_as_dirty,omitempty"`
+
 	// Max git checker workers
 	MaxWorkers int `toml:"maxWorkers"`
 

--- a/internal/filter_repoState_test.go
+++ b/internal/filter_repoState_test.go
@@ -33,14 +33,57 @@ func makeRepoState(uncommited, unpushed, unpulled bool) report.RepoState {
 	return rs
 }
 
+// makeStashOnlyRepoState builds a clean repo whose only local state is a stash.
+func makeStashOnlyRepoState() report.RepoState {
+	rs := makeRepoState(false, false, false)
+	rs.Stashes = []string{"stash@{0}: WIP on main: abc123 msg"}
+	return rs
+}
+
+func TestFilter_OnlyStash_AllowsOnlyReposWithStashes(t *testing.T) {
+	clean := makeRepoState(false, false, false)
+	stash := makeStashOnlyRepoState()
+
+	// flag must not affect OnlyStash in either direction
+	for _, flag := range []bool{false, true} {
+		if filter(config.OnlyStash, clean, flag) {
+			t.Fatalf("OnlyStash should exclude repos without stashes (flag=%v)", flag)
+		}
+		if !filter(config.OnlyStash, stash, flag) {
+			t.Fatalf("OnlyStash should include repos with stashes (flag=%v)", flag)
+		}
+	}
+}
+
+func TestFilter_OnlyDirty_StashRespectsCountStashAsDirty(t *testing.T) {
+	stash := makeStashOnlyRepoState()
+
+	if filter(config.OnlyDirty, stash, false) {
+		t.Fatalf("OnlyDirty should exclude stash-only repos when countStashAsDirty=false")
+	}
+	if !filter(config.OnlyDirty, stash, true) {
+		t.Fatalf("OnlyDirty should include stash-only repos when countStashAsDirty=true")
+	}
+}
+
+func TestFilter_StashOnlyRepo_ExcludedFromOtherFilters(t *testing.T) {
+	stash := makeStashOnlyRepoState()
+
+	for _, f := range []config.OnlyFilter{config.OnlyUncommitted, config.OnlyUnpushed, config.OnlyUnpulled} {
+		if filter(f, stash, true) {
+			t.Fatalf("filter %q should exclude stash-only repos", f)
+		}
+	}
+}
+
 func TestFilter_OnlyAll_AllowsAnyRepo(t *testing.T) {
 	clean := makeRepoState(false, false, false)
 	dirty := makeRepoState(true, false, false)
 
-	if !filter(config.OnlyAll, clean) {
+	if !filter(config.OnlyAll, clean, false) {
 		t.Fatalf("OnlyAll should include clean repos")
 	}
-	if !filter(config.OnlyAll, dirty) {
+	if !filter(config.OnlyAll, dirty, false) {
 		t.Fatalf("OnlyAll should include dirty repos")
 	}
 }
@@ -52,19 +95,19 @@ func TestFilter_OnlyUncommitted_AllowsOnlyReposWithUncommitedChanges(t *testing.
 	dirty2 := makeRepoState(false, true, false)
 	dirty3 := makeRepoState(false, false, true)
 
-	if filter(config.OnlyUncommitted, clean) {
+	if filter(config.OnlyUncommitted, clean, false) {
 		t.Fatalf("OnlyUncommitted should exclude clean repos")
 	}
 
-	if !filter(config.OnlyUncommitted, dirty1) {
+	if !filter(config.OnlyUncommitted, dirty1, false) {
 		t.Fatalf("OnlyUncommitted should include dirty repos, 1")
 	}
 
-	if filter(config.OnlyUncommitted, dirty2) {
+	if filter(config.OnlyUncommitted, dirty2, false) {
 		t.Fatalf("OnlyUncommitted should include dirty repos, 2")
 	}
 
-	if filter(config.OnlyUncommitted, dirty3) {
+	if filter(config.OnlyUncommitted, dirty3, false) {
 		t.Fatalf("OnlyUncommitted should include dirty repos, 3")
 	}
 }
@@ -76,19 +119,19 @@ func TestFilter_OnlyUnpushed_AllowsOnlyReposWithUnpushedCommits(t *testing.T) {
 	dirty2 := makeRepoState(false, true, false)
 	dirty3 := makeRepoState(false, false, true)
 
-	if filter(config.OnlyUnpushed, clean) {
+	if filter(config.OnlyUnpushed, clean, false) {
 		t.Fatalf("OnlyUnpushed should exclude clean repos")
 	}
 
-	if filter(config.OnlyUnpushed, dirty1) {
+	if filter(config.OnlyUnpushed, dirty1, false) {
 		t.Fatalf("OnlyUnpushed should include dirty repos, 1")
 	}
 
-	if !filter(config.OnlyUnpushed, dirty2) {
+	if !filter(config.OnlyUnpushed, dirty2, false) {
 		t.Fatalf("OnlyUnpushed should include dirty repos, 2")
 	}
 
-	if filter(config.OnlyUnpushed, dirty3) {
+	if filter(config.OnlyUnpushed, dirty3, false) {
 		t.Fatalf("OnlyUnpushed should include dirty repos, 3")
 	}
 }
@@ -100,19 +143,19 @@ func TestFilter_OnlyUnpulled_AllowsOnlyReposWithUnpulledCommits(t *testing.T) {
 	dirty2 := makeRepoState(false, true, false)
 	dirty3 := makeRepoState(false, false, true)
 
-	if filter(config.OnlyUnpulled, clean) {
+	if filter(config.OnlyUnpulled, clean, false) {
 		t.Fatalf("OnlyUnpulled should exclude clean repos")
 	}
 
-	if filter(config.OnlyUnpulled, dirty1) {
+	if filter(config.OnlyUnpulled, dirty1, false) {
 		t.Fatalf("OnlyUnpulled should include dirty repos, 1")
 	}
 
-	if filter(config.OnlyUnpulled, dirty2) {
+	if filter(config.OnlyUnpulled, dirty2, false) {
 		t.Fatalf("OnlyUnpulled should include dirty repos, 2")
 	}
 
-	if !filter(config.OnlyUnpulled, dirty3) {
+	if !filter(config.OnlyUnpulled, dirty3, false) {
 		t.Fatalf("OnlyUnpulled should include dirty repos, 3")
 	}
 }
@@ -123,19 +166,19 @@ func TestFilter_OnlyDirty_AllowsOnlyDirtyRepos(t *testing.T) {
 	dirty2 := makeRepoState(false, true, false)
 	dirty3 := makeRepoState(false, false, true)
 
-	if filter(config.OnlyDirty, clean) {
+	if filter(config.OnlyDirty, clean, false) {
 		t.Fatalf("OnlyDirty should exclude clean repos")
 	}
 
-	if !filter(config.OnlyDirty, dirty1) {
+	if !filter(config.OnlyDirty, dirty1, false) {
 		t.Fatalf("OnlyDirty should include dirty repos")
 	}
 
-	if !filter(config.OnlyDirty, dirty2) {
+	if !filter(config.OnlyDirty, dirty2, false) {
 		t.Fatalf("OnlyDirty should include dirty repos")
 	}
 
-	if !filter(config.OnlyDirty, dirty3) {
+	if !filter(config.OnlyDirty, dirty3, false) {
 		t.Fatalf("OnlyDirty should include dirty repos")
 	}
 }

--- a/internal/gitx/gitFunctions.go
+++ b/internal/gitx/gitFunctions.go
@@ -80,6 +80,21 @@ func GetUncommitedFiles(path string) (changes []string, err error) {
 	return changes, nil
 }
 
+// GetStashes returns the list of stash entries (one per `git stash list` line)
+// for the Git repository at path. Stashes are stored in the shared refs/stash
+// of the common dir, so linked worktrees report the same stashes.
+func GetStashes(path string) (stashes []string, err error) {
+	str, err := RunGitCommand(path, "stash", "list")
+	if err != nil {
+		return []string{}, err
+	}
+
+	stashes = strings.Split(strings.TrimRight(str, "\n"), "\n")
+	stashes = removeEmptyStrings(stashes)
+
+	return stashes, nil
+}
+
 // GetUpstreamStatus returns the ahead/behind counts relative to the upstream
 // tracking branch for the repository at path.
 func GetUpstreamStatus(path string) (ahead int, behind int, err error) {

--- a/internal/gitx/gitFunctions_test.go
+++ b/internal/gitx/gitFunctions_test.go
@@ -1,0 +1,78 @@
+package gitx
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func gitOrSkip(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := append([]string{"-C", dir,
+		"-c", "user.email=test@example.com",
+		"-c", "user.name=test",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", full...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestGetStashes_NoStashes(t *testing.T) {
+	gitOrSkip(t)
+	repo := t.TempDir()
+	runGit(t, repo, "init")
+
+	stashes, err := GetStashes(repo)
+	if err != nil {
+		t.Fatalf("GetStashes: %v", err)
+	}
+	if len(stashes) != 0 {
+		t.Fatalf("expected 0 stashes, got %d: %v", len(stashes), stashes)
+	}
+}
+
+// A stash lives in the shared refs/stash of the common dir, so a stash made in
+// the main worktree must also be visible from a linked worktree.
+func TestGetStashes_SharedAcrossWorktrees(t *testing.T) {
+	gitOrSkip(t)
+	base := t.TempDir()
+	repo := filepath.Join(base, "main")
+	runGit(t, base, "init", "main")
+
+	file := filepath.Join(repo, "f.txt")
+	if err := os.WriteFile(file, []byte("v1\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, repo, "add", "f.txt")
+	runGit(t, repo, "commit", "-m", "initial")
+
+	// linked worktree on a new branch
+	wt := filepath.Join(base, "wt")
+	runGit(t, repo, "worktree", "add", "-b", "feature", wt)
+
+	// create a stash in the main worktree
+	if err := os.WriteFile(file, []byte("v2\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, repo, "stash")
+
+	for _, path := range []string{repo, wt} {
+		stashes, err := GetStashes(path)
+		if err != nil {
+			t.Fatalf("GetStashes(%s): %v", path, err)
+		}
+		if len(stashes) != 1 {
+			t.Fatalf("expected 1 stash at %s, got %d: %v", path, len(stashes), stashes)
+		}
+	}
+}

--- a/internal/gitx/gitx.go
+++ b/internal/gitx/gitx.go
@@ -65,6 +65,12 @@ func CheckRepoState(path string) (repoState report.RepoState, warnings []string)
 		warnings = append(warnings, msg)
 	}
 
+	stashes, err := GetStashes(path)
+	if err != nil {
+		msg := "Failed to get stashes, path=" + path
+		warnings = append(warnings, msg)
+	}
+
 	return report.RepoState{
 		ID:              utils.Hash(path),
 		Path:            path,
@@ -72,6 +78,7 @@ func CheckRepoState(path string) (repoState report.RepoState, warnings []string)
 		Branch:          branch,
 		UncommitedFiles: uncommitedFiles,
 		RemoteStatus:    remoteStatuses,
+		Stashes:         stashes,
 	}, warnings
 }
 

--- a/internal/render/tui/main.go
+++ b/internal/render/tui/main.go
@@ -56,7 +56,7 @@ func Render(
 	reposTableHeader := rth.Header{
 		Theme: theme,
 	}
-	reposTableHeader.SetReport(r)
+	reposTableHeader.SetReport(r, configs.CountStashAsDirty)
 
 	var repoDetails repodetails.Model
 	if len(r.RepoStates) == 0 {

--- a/internal/render/tui/repostable/ui.go
+++ b/internal/render/tui/repostable/ui.go
@@ -11,19 +11,22 @@ import (
 )
 
 const (
-	RepoW        = 30
-	BranchW      = 30
-	RemoteStateW = 40
+	RepoW        = 28
+	BranchW      = 26
+	StashW       = 10
+	RemoteStateW = 36
 )
 
 func createColumns(maxWidth int) []table.Column {
 	repoW := maxWidth * RepoW / 100
 	branchW := maxWidth * BranchW / 100
+	stashW := maxWidth * StashW / 100
 	remoteStateW := maxWidth * RemoteStateW / 100
 
 	return []table.Column{
 		{Title: "Repo", Width: repoW},
 		{Title: "Branch", Width: branchW},
+		{Title: "Stash", Width: stashW},
 		{Title: "State", Width: remoteStateW},
 	}
 }
@@ -36,10 +39,18 @@ func createRows(repoStates []report.RepoState, theme theme.Theme) []table.Row {
 		rows = append(rows, table.Row{
 			rs.Repo,
 			rs.Branch,
+			stashColumnStr(rs),
 			state,
 		})
 	}
 	return rows
+}
+
+func stashColumnStr(rs report.RepoState) string {
+	if rs.StashCount() == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%d", rs.StashCount())
 }
 
 func getStateColumnStr(rs report.RepoState, theme theme.Theme) string {

--- a/internal/render/tui/repostable/ui.go
+++ b/internal/render/tui/repostable/ui.go
@@ -47,10 +47,11 @@ func createRows(repoStates []report.RepoState, theme theme.Theme) []table.Row {
 }
 
 func stashColumnStr(rs report.RepoState) string {
-	if rs.StashCount() == 0 {
+	n := rs.StashCount()
+	if n == 0 {
 		return ""
 	}
-	return fmt.Sprintf("%d", rs.StashCount())
+	return fmt.Sprintf("%d", n)
 }
 
 func getStateColumnStr(rs report.RepoState, theme theme.Theme) string {

--- a/internal/render/tui/repostableheader/reposTableHeader.go
+++ b/internal/render/tui/repostableheader/reposTableHeader.go
@@ -15,9 +15,9 @@ type Header struct {
 	Theme           theme.Theme
 }
 
-func (h *Header) SetReport(report report.ScanReport) {
+func (h *Header) SetReport(report report.ScanReport, countStashAsDirty bool) {
 	h.repoStatesCount = len(report.RepoStates)
-	h.dirtyRepos = report.DirtyReposCount()
+	h.dirtyRepos = report.DirtyReposCount(countStashAsDirty)
 
 }
 

--- a/internal/scanGenerator.go
+++ b/internal/scanGenerator.go
@@ -47,7 +47,7 @@ func filter(f config.OnlyFilter, repoState report.RepoState, countStashAsDirty b
 	case config.OnlyAll:
 		return true
 	case config.OnlyDirty:
-		if repoState.IsDirty() || (countStashAsDirty && repoState.HaveStashes()) {
+		if repoState.IsDirty(countStashAsDirty) {
 			return true
 		}
 	case config.OnlyUncommitted:

--- a/internal/scanGenerator.go
+++ b/internal/scanGenerator.go
@@ -26,7 +26,7 @@ func GenerateScanReport(
 
 	// filter repo states based on config OnlyFilter
 	for _, repoState := range allRepoStates {
-		if filter(configs.Only, repoState) {
+		if filter(configs.Only, repoState, configs.CountStashAsDirty) {
 			repoStates = append(repoStates, repoState)
 		}
 	}
@@ -40,13 +40,14 @@ func GenerateScanReport(
 }
 
 // Filter repoState based on config only filter
-// Returns true if repoState should be in output, false otherwise
-func filter(f config.OnlyFilter, repoState report.RepoState) bool {
+// Returns true if repoState should be in output, false otherwise.
+// countStashAsDirty only affects the OnlyDirty case; OnlyStash is independent.
+func filter(f config.OnlyFilter, repoState report.RepoState, countStashAsDirty bool) bool {
 	switch f {
 	case config.OnlyAll:
 		return true
 	case config.OnlyDirty:
-		if repoState.IsDirty() {
+		if repoState.IsDirty() || (countStashAsDirty && repoState.HaveStashes()) {
 			return true
 		}
 	case config.OnlyUncommitted:
@@ -57,6 +58,8 @@ func filter(f config.OnlyFilter, repoState report.RepoState) bool {
 		return repoState.HaveUnpushedCommits()
 	case config.OnlyUnpulled:
 		return repoState.HaveUnpulledCommits()
+	case config.OnlyStash:
+		return repoState.HaveStashes()
 	}
 
 	return false

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -34,14 +34,19 @@ type ScanReport struct {
 }
 
 // IsDirty reports whether the repository has uncommitted changes or is ahead/behind.
-func (r *RepoState) IsDirty() bool {
+// When countStashAsDirty is true, a repo whose only local state is stashed work
+// is also reported as dirty.
+func (r *RepoState) IsDirty(countStashAsDirty bool) bool {
 	atLeastOneDirtyRemote := false
 	for _, remoteStatus := range r.RemoteStatus {
 		if remoteStatus.Ahead > 0 || remoteStatus.Behind > 0 {
 			atLeastOneDirtyRemote = true
 		}
 	}
-	return len(r.UncommitedFiles) > 0 || atLeastOneDirtyRemote
+	if len(r.UncommitedFiles) > 0 || atLeastOneDirtyRemote {
+		return true
+	}
+	return countStashAsDirty && r.HaveStashes()
 }
 
 func (r *RepoState) HaveUnpushedCommits() bool {
@@ -73,11 +78,11 @@ func (r *RepoState) StashCount() int {
 }
 
 // DirtyReposCount count all dirty repos based on [IsDirty] function on RepoState struct.
-// When countStashAsDirty is true, repos whose only local state is stashed work are also counted.
+// countStashAsDirty is forwarded to IsDirty.
 func (sc *ScanReport) DirtyReposCount(countStashAsDirty bool) int {
 	dirtyRepos := 0
 	for _, rs := range sc.RepoStates {
-		if rs.IsDirty() || (countStashAsDirty && rs.HaveStashes()) {
+		if rs.IsDirty(countStashAsDirty) {
 			dirtyRepos++
 		}
 	}

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -21,6 +21,7 @@ type RepoState struct {
 	Branch          string         `json:"branch"`
 	UncommitedFiles []string       `json:"uncommitedFiles"`
 	RemoteStatus    []RemoteStatus `json:"remoteStatus"`
+	Stashes         []string       `json:"stashes"`
 }
 
 // ScanReport aggregates the results of scanning one or more directories for
@@ -61,11 +62,22 @@ func (r *RepoState) HaveUnpulledCommits() bool {
 	return false
 }
 
-// DirtyReposCount count all dirty repos based on [IsDirty] function on RepoState struct
-func (sc *ScanReport) DirtyReposCount() int {
+// HaveStashes reports whether the repository has any stash entries.
+func (r *RepoState) HaveStashes() bool {
+	return len(r.Stashes) > 0
+}
+
+// StashCount returns the number of stash entries for the repository.
+func (r *RepoState) StashCount() int {
+	return len(r.Stashes)
+}
+
+// DirtyReposCount count all dirty repos based on [IsDirty] function on RepoState struct.
+// When countStashAsDirty is true, repos whose only local state is stashed work are also counted.
+func (sc *ScanReport) DirtyReposCount(countStashAsDirty bool) int {
 	dirtyRepos := 0
 	for _, rs := range sc.RepoStates {
-		if rs.IsDirty() {
+		if rs.IsDirty() || (countStashAsDirty && rs.HaveStashes()) {
 			dirtyRepos++
 		}
 	}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -1,0 +1,43 @@
+package report
+
+import "testing"
+
+func TestHaveStashesAndStashCount(t *testing.T) {
+	none := RepoState{}
+	if none.HaveStashes() {
+		t.Fatalf("HaveStashes should be false for empty Stashes")
+	}
+	if none.StashCount() != 0 {
+		t.Fatalf("StashCount should be 0 for empty Stashes")
+	}
+
+	with := RepoState{Stashes: []string{"stash@{0}: WIP", "stash@{1}: WIP"}}
+	if !with.HaveStashes() {
+		t.Fatalf("HaveStashes should be true when Stashes present")
+	}
+	if with.StashCount() != 2 {
+		t.Fatalf("StashCount should be 2, got %d", with.StashCount())
+	}
+}
+
+func TestIsDirty_StashOnlyIsNotDirty(t *testing.T) {
+	rs := RepoState{Stashes: []string{"stash@{0}: WIP"}}
+	if rs.IsDirty() {
+		t.Fatalf("IsDirty must not consider stashes; stash-only repo should be clean")
+	}
+}
+
+func TestDirtyReposCount_StashRespectsFlag(t *testing.T) {
+	stashOnly := RepoState{Stashes: []string{"stash@{0}: WIP"}}
+	uncommitted := RepoState{UncommitedFiles: []string{"file.txt"}}
+	clean := RepoState{}
+
+	sc := ScanReport{RepoStates: []RepoState{stashOnly, uncommitted, clean}}
+
+	if got := sc.DirtyReposCount(false); got != 1 {
+		t.Fatalf("DirtyReposCount(false) should count only the uncommitted repo, got %d", got)
+	}
+	if got := sc.DirtyReposCount(true); got != 2 {
+		t.Fatalf("DirtyReposCount(true) should count uncommitted + stash-only, got %d", got)
+	}
+}

--- a/pkg/report/report_test.go
+++ b/pkg/report/report_test.go
@@ -20,10 +20,13 @@ func TestHaveStashesAndStashCount(t *testing.T) {
 	}
 }
 
-func TestIsDirty_StashOnlyIsNotDirty(t *testing.T) {
+func TestIsDirty_StashOnlyRespectsFlag(t *testing.T) {
 	rs := RepoState{Stashes: []string{"stash@{0}: WIP"}}
-	if rs.IsDirty() {
-		t.Fatalf("IsDirty must not consider stashes; stash-only repo should be clean")
+	if rs.IsDirty(false) {
+		t.Fatalf("IsDirty(false) must not consider stashes; stash-only repo should be clean")
+	}
+	if !rs.IsDirty(true) {
+		t.Fatalf("IsDirty(true) must consider stash-only repo as dirty")
 	}
 }
 

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -8,8 +8,12 @@ roots = [
     "/home/mabd/"
 ]
 
-# options: all|dirty
+# options: all|dirty|uncommitted|unpushed|unpulled|stash
 only = 'dirty'
+
+# Count repos whose only local state is stashed work as dirty (default false).
+# Only affects only='dirty'; only='stash' is unaffected.
+count_stash_as_dirty = false
 
 dirIgnore = [
     # --- Package managers / deps ---


### PR DESCRIPTION
A repo with a clean working tree, nothing ahead/behind, but a stack of stashes was reported as **clean** — a false negative, since a stash holds real local-only work invisible to `git status`. This surfaces stash entries per repo.

Per your feedback on the issue:
- Stash → dirty is **opt-in** via a new `count_stash_as_dirty` config key (default `false`). When `false`, stashes are informational only and `--filter dirty` ignores them.
- `--filter stash` is always valid and independent of that flag.
- Stashes are stored as a **list** (`stashes []string`, raw `git stash list` lines), with count derived — leaving room to display the list in the TUI later. This mirrors how `uncommitedFiles` is stored, so no separate `stashCount` JSON field is added (consumers use `len`).
- Table output is gone, so TUI gets a small **Stash** column between `Branch` and `State`.
- `git stash` is per-repo (shared `refs/stash`), so each worktree row of a repo shows the same stash count — covered by a unit test.

## Changes Made

- `gitx`: `GetStashes()` (network-free `git stash list`); populated in `CheckRepoState` with a non-fatal warning on error.
- `report`: `Stashes []string` (`json:"stashes"`), `HaveStashes()`, `StashCount()`. `IsDirty()` unchanged; `DirtyReposCount(countStashAsDirty bool)`.
- `config`: `count_stash_as_dirty` (default false); new `stash` value for `--filter`.
- Filter: `OnlyDirty` becomes `IsDirty() || (countStashAsDirty && HaveStashes())`; new `OnlyStash` case (flag-independent).
- TUI: `Stash` column between Branch and State (blank when 0); header dirty count respects the flag.
- Docs: README, `docs/cli-flags.md`, `sample/config.toml`, flag help text, CHANGELOG.

## Testing

- [x] Tested locally with example workflows
- [x] Added new tests (if applicable)
- [x] Tested with different `filters`, `output`, etc...

`go test ./...` green, including `CGO_ENABLED=0` (matches CI). New tests: report predicates + `DirtyReposCount` flag behavior; filter cases (`stash` inclusion, `dirty` respecting the flag, exclusion from other filters); and a gitx integration test asserting a stash made in the main worktree is visible from a linked worktree (shared `refs/stash`).

Manually verified via `-o json` (`-f stash`, `-f dirty` with the flag on/off) and **visually inspected the interactive TUI** with three repos (0 / 1 / 3 stashes, one with a linked worktree) to confirm the new **Stash** column renders correctly and the worktree row mirrors its repo's stash count.

## Screenshots (if applicable)

_TUI now shows a `Stash` column between `Branch` and `State`; 0 renders blank._

<img width="2560" height="1541" alt="image" src="https://github.com/user-attachments/assets/c3e463d7-3c74-420d-868d-981814ab66d1" />

## Checklist

- [x] My code follows the project's code style
- [x] I have updated the documentation (README, cli-flags, etc...)
- [x] My changes generate no new warnings
- [x] I have tested my changes in a real workflow
- [x] All tests pass locally

## Additional Notes

Out of scope (per the issue): stash apply/drop, parsing stash lines into structs, and rendering the stash list in the details panel (left as the later TUI enhancement you mentioned). No CLI flag for `count_stash_as_dirty` — config-only, as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR detects stashed changes as a new repository state, surfacing them in the TUI, JSON output, and filter system. An opt-in `count_stash_as_dirty` config key (default `false`) controls whether stash-only repos contribute to the dirty count, while `--filter stash` is always independent of that flag.

- **`GetStashes`** runs `git stash list` per repo path; because stashes live in the shared `refs/stash` of the common dir, linked worktrees correctly report the same stash entries, verified by a new integration test.
- **`RepoState.Stashes []string`** is added as a public JSON field (`"stashes"`); `HaveStashes()` / `StashCount()` are new predicates; `DirtyReposCount` gains a `countStashAsDirty bool` parameter.
- **TUI** receives a new `Stash` column (10 % of width) between `Branch` and `State`; blank when count is zero; column widths re-proportioned to keep the total at 100 %.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the stash detection path is additive, non-fatal on error, and the existing dirty/uncommitted/unpushed/unpulled filters are fully unchanged when countStashAsDirty is false (the default).

The implementation is straightforward and well-tested: unit tests cover all new predicates and filter combinations, and an integration test verifies the shared-stash-across-worktrees property. The only finding is a cosmetic double call to StashCount() in the TUI helper.

No files require special attention; internal/render/tui/repostable/ui.go has the minor double-call style note.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/gitx/gitFunctions.go | Adds GetStashes() following the same TrimRight+Split+removeEmptyStrings pattern as GetUncommitedFiles; correctly returns []string{} on error. |
| internal/gitx/gitx.go | Integrates GetStashes into CheckRepoState with a non-fatal warning on error, consistent with how uncommitted-files and remote-status errors are handled. |
| pkg/report/report.go | Adds Stashes field, HaveStashes/StashCount predicates, and updates DirtyReposCount to accept countStashAsDirty; logic is correct and IsDirty() intentionally left unchanged. |
| internal/scanGenerator.go | filter() gains countStashAsDirty param and OnlyStash case; OnlyDirty condition correctly extends with || guard; all existing test cases updated. |
| internal/render/tui/repostable/ui.go | Adds Stash column and stashColumnStr helper; calls StashCount() twice in the helper — minor style issue. |
| internal/gitx/gitFunctions_test.go | New integration tests cover no-stash repos and the shared-stash-across-worktrees property; uses t.TempDir() and skips when git is absent. |
| pkg/report/report_test.go | New unit tests validate HaveStashes, StashCount, IsDirty stash exclusion, and DirtyReposCount flag behaviour. |
| internal/filter_repoState_test.go | All existing tests updated to pass countStashAsDirty param; three new test cases cover OnlyStash, countStashAsDirty flag toggling, and exclusion from other filters. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CheckRepoState] --> B[GetStashes\ngit stash list]
    B -->|success| C[Stashes: populated]
    B -->|error| D[warning appended\nStashes: empty slice]
    C --> E[RepoState.Stashes]
    D --> E

    E --> F{filter}
    F -->|OnlyStash| G[HaveStashes?]
    F -->|OnlyDirty| H[IsDirty?\nOR countStashAsDirty\n&& HaveStashes?]
    F -->|OnlyAll| I[always include]
    F -->|Uncommitted\nUnpushed\nUnpulled| J[existing predicates\nunaffected]

    G -->|yes| K[include in output]
    H -->|yes| K
    I --> K

    K --> L[TUI: Stash column\nblank if 0]
    K --> M[JSON: stashes array]
    K --> N[Header: DirtyReposCount\ncountStashAsDirty flag]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: detect stashed changes as a repo s..."](https://github.com/mabd-dev/reposcan/commit/08cbd1142377069e9a606096ebd81992c3ae60b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34540091)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->