### PR TITLE
Feat/color uncommited files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changes
 
+- feat/colorUncommitedFiles: Get color based on file git status by @mabd-dev in [#50](https://github.com/mabd-dev/reposcan/pull/50)
 - feat/detect-stashes: Detect stashed changes as a repo state; adds `stash` filter and opt-in `countStashAsDirty` config by @nilp0inter in [#47](https://github.com/mabd-dev/reposcan/pull/47)
 - feat/supportWorktree: Detect git worktrees and submodules (`.git` file with `gitdir:` pointer) during repo scan by @mabd-dev in [#43](https://github.com/mabd-dev/reposcan/pull/43)
 

--- a/internal/render/tui/repodetails/view.go
+++ b/internal/render/tui/repodetails/view.go
@@ -61,6 +61,10 @@ func (m *Model) buildUncommittedFiles() []string {
 }
 
 func getFileStatusColor(symbol string, colors theme.LipglossScheme) lipgloss.Color {
+	if len(symbol) != 2 {
+		return colors.Foreground
+	}
+
 	staged := string(symbol[0])
 	unstaged := string(symbol[1])
 

--- a/internal/render/tui/repodetails/view.go
+++ b/internal/render/tui/repodetails/view.go
@@ -15,9 +15,10 @@ func (m *Model) View() string {
 	}
 
 	style := m.theme.Styles.Base.Foreground(m.theme.Colors.Info).Bold(true)
+	pathStyle := m.theme.Styles.Base.Foreground(m.theme.Colors.Foreground)
 
 	lines := []string{
-		fmt.Sprintf("%s %s", style.Render("Path:"), m.repoState.Path),
+		fmt.Sprintf("%s %s", style.Render("Path:"), pathStyle.Render(m.repoState.Path)),
 		style.Render("File Changes:"),
 	}
 

--- a/internal/render/tui/repodetails/view.go
+++ b/internal/render/tui/repodetails/view.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mabd-dev/reposcan/internal/theme"
 )
 
 func (m *Model) View() string {
@@ -46,7 +47,9 @@ func (m *Model) buildUncommittedFiles() []string {
 	}
 
 	for _, f := range files {
-		lines = append(lines, "  "+fileStyle.Render(f))
+		changeSymbol := f[:2]
+		color := getFileStatusColor(changeSymbol, m.theme.Colors)
+		lines = append(lines, "  "+fileStyle.Foreground(color).Render(f))
 	}
 
 	if trimUncommitedFiles {
@@ -55,4 +58,35 @@ func (m *Model) buildUncommittedFiles() []string {
 	}
 
 	return lines
+}
+
+func getFileStatusColor(symbol string, colors theme.LipglossScheme) lipgloss.Color {
+	staged := string(symbol[0])
+	unstaged := string(symbol[1])
+
+	if symbol == "??" {
+		return colors.Muted
+	}
+
+	if staged == "A" {
+		return colors.Success
+	}
+
+	if staged == "D" || unstaged == "D" {
+		return colors.Error
+	}
+
+	if staged == "R" {
+		return colors.Accent
+	}
+
+	if staged == "U" || unstaged == "U" {
+		return colors.Warning
+	}
+
+	if staged == "M" || unstaged == "M" {
+		return colors.PopupTitle
+	}
+
+	return colors.Foreground
 }

--- a/internal/render/tui/repodetails/view.go
+++ b/internal/render/tui/repodetails/view.go
@@ -13,34 +13,46 @@ func (m *Model) View() string {
 		return ""
 	}
 
-	style := m.theme.Styles.Base.Foreground(m.theme.Colors.Info)
+	style := m.theme.Styles.Base.Foreground(m.theme.Colors.Info).Bold(true)
 
 	lines := []string{
-		//m.theme.Styles.Base.Foreground(m.theme.Colors.Muted).Italic(true).Render("Details"),
 		fmt.Sprintf("%s %s", style.Render("Path:"), m.repoState.Path),
 		style.Render("File Changes:"),
 	}
-	if len(m.repoState.UncommitedFiles) > 0 {
-		files := m.repoState.UncommitedFiles
 
-		maxUncommitedFilesToShow := m.height - len(lines) - 1
-		trimUncommitedFiles := len(files) > maxUncommitedFilesToShow
-
-		if trimUncommitedFiles {
-			files = files[:maxUncommitedFilesToShow]
-		}
-
-		for _, f := range files {
-			lines = append(lines, "  "+m.theme.Styles.Muted.Render(f))
-		}
-
-		if trimUncommitedFiles {
-			more := len(m.repoState.UncommitedFiles) - maxUncommitedFilesToShow
-			lines = append(lines, m.theme.Styles.Muted.Render("  ... (+"+strconv.Itoa(more)+" more)"))
-		}
-	} else {
-		lines = append(lines, m.theme.Styles.Muted.Render("    no changes"))
-	}
+	lines = append(lines, m.buildUncommittedFiles()...)
 
 	return lipgloss.JoinVertical(lipgloss.Left, lines...)
+}
+
+func (m *Model) buildUncommittedFiles() []string {
+
+	files := m.repoState.UncommitedFiles
+	if len(files) == 0 {
+		return []string{
+			m.theme.Styles.Muted.Render("    no changes"),
+		}
+	}
+
+	lines := []string{}
+
+	fileStyle := m.theme.Styles.Base.Foreground(m.theme.Colors.Foreground)
+
+	maxUncommitedFilesToShow := m.height - len(files) - 1
+	trimUncommitedFiles := len(files) > maxUncommitedFilesToShow
+
+	if trimUncommitedFiles {
+		files = files[:maxUncommitedFilesToShow]
+	}
+
+	for _, f := range files {
+		lines = append(lines, "  "+fileStyle.Render(f))
+	}
+
+	if trimUncommitedFiles {
+		more := len(m.repoState.UncommitedFiles) - maxUncommitedFilesToShow
+		lines = append(lines, fileStyle.Render("  ... (+"+strconv.Itoa(more)+" more)"))
+	}
+
+	return lines
 }

--- a/internal/render/tui/repodetails/view_test.go
+++ b/internal/render/tui/repodetails/view_test.go
@@ -1,0 +1,97 @@
+package repodetails
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/mabd-dev/reposcan/internal/theme"
+)
+
+func generateFakeLipGlossScheme() theme.LipglossScheme {
+	return theme.LipglossScheme{
+		Background: lipgloss.Color("#000001"),
+		Foreground: lipgloss.Color("#000002"),
+		Accent:     lipgloss.Color("#000003"),
+
+		Muted:   lipgloss.Color("#000004"),
+		Error:   lipgloss.Color("#000005"),
+		Warning: lipgloss.Color("#000006"),
+		Success: lipgloss.Color("#000007"),
+		Info:    lipgloss.Color("#000008"),
+
+		Border:       lipgloss.Color("#000009"),
+		BorderActive: lipgloss.Color("#000010"),
+
+		TableHeader: lipgloss.Color("#000011"),
+		TableRow:    lipgloss.Color("#000012"),
+		TableAltRow: lipgloss.Color("#000013"),
+
+		PopupBackground: lipgloss.Color("#000014"),
+		PopupBorder:     lipgloss.Color("#000015"),
+		PopupTitle:      lipgloss.Color("#000010"),
+	}
+}
+
+func TestGetFileStatusColor(t *testing.T) {
+	colors := generateFakeLipGlossScheme()
+
+	tests := []struct {
+		symbol        string
+		expectedColor lipgloss.Color
+	}{
+		{
+			symbol:        "??",
+			expectedColor: colors.Muted,
+		},
+		{
+			symbol:        "A ",
+			expectedColor: colors.Success,
+		},
+		{
+			symbol:        "D ",
+			expectedColor: colors.Error,
+		},
+		{
+			symbol:        " D",
+			expectedColor: colors.Error,
+		},
+		{
+			symbol:        "R ",
+			expectedColor: colors.Accent,
+		},
+		{
+			symbol:        "U ",
+			expectedColor: colors.Warning,
+		},
+		{
+			symbol:        " U",
+			expectedColor: colors.Warning,
+		},
+		{
+			symbol:        "M ",
+			expectedColor: colors.PopupTitle,
+		},
+		{
+			symbol:        " M",
+			expectedColor: colors.PopupTitle,
+		},
+		{
+			symbol:        "asdf",
+			expectedColor: colors.Foreground,
+		},
+		{
+			symbol:        "",
+			expectedColor: colors.Foreground,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("Test Color %v", test.symbol), func(t *testing.T) {
+			if color := getFileStatusColor(test.symbol, colors); color != test.expectedColor {
+				t.Fatalf("expected %v found %v (symbol=??)", test.expectedColor, color)
+			}
+		})
+	}
+
+}

--- a/internal/render/tui/repodetails/view_test.go
+++ b/internal/render/tui/repodetails/view_test.go
@@ -89,7 +89,7 @@ func TestGetFileStatusColor(t *testing.T) {
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Test Color %v", test.symbol), func(t *testing.T) {
 			if color := getFileStatusColor(test.symbol, colors); color != test.expectedColor {
-				t.Fatalf("expected %v found %v (symbol=??)", test.expectedColor, color)
+				t.Fatalf("expected %v found %v (symbol=%v)", test.expectedColor, color, test.symbol)
 			}
 		})
 	}


### PR DESCRIPTION
# Pull Request

## Description

Color Uncommitted files based on file status. 
Data already existed, I just parsed the file staged/unstaged status and figure out the color

## Changes Made

-  Added a function to get color based on status symbol. First 2 characters determines the state
    - first character: staged state
    - second character: unstaged state
    
<img width="361" height="102" alt="Screenshot 2026-05-30 at 7 56 42 AM" src="https://github.com/user-attachments/assets/26a74ae8-60b1-4901-9c7b-20bcf3c23719" />
- Added unit tests to cover all cases

## Testing

<!-- Describe how you tested your changes -->

- [x] Tested locally with example workflows
- [x] Added new tests (if applicable)
- [x] Tested with different `filters`, `output`, etc...

## Screenshots (if applicable)

<img width="1341" height="747" alt="Screenshot 2026-05-30 at 7 54 30 AM" src="https://github.com/user-attachments/assets/078f552d-f014-465a-8093-a0a8f1cc5354" />


## Checklist

- [x] I have starred the repository
- [x] My code follows the project's code style
- [ ] I have updated the documentation (README, cli-flags, etc...)
- [x] My changes generate no new warnings
- [x] I have tested my changes in a real workflow
- [x] All tests pass locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds color coding to uncommitted files in the TUI details panel, using the first two characters of each git porcelain status line to pick a themed color (added=success, deleted=error, renamed=accent, unmerged=warning, modified=`PopupTitle`, untracked=muted).

- `buildUncommittedFiles()` is extracted from `View()` and now maps status symbols to colors; the `View()` header labels also gain bold styling and explicit foreground color.
- New table-driven tests in `view_test.go` cover all supported status symbol combinations.
- A regression was introduced: `maxUncommitedFilesToShow` is computed using `len(files)` (file count) instead of the 2 fixed header lines from the original code, which will cause a runtime panic when the number of uncommitted files exceeds the terminal height.

<h3>Confidence Score: 3/5</h3>

The TUI details panel will panic with a slice-bounds error if the number of uncommitted files exceeds the terminal height, which is a realistic scenario for repos with many staged/unstaged changes.

The len(files) vs constant-2 mistake in the trimming calculation directly causes files[:negative_number] at runtime — a guaranteed panic for any repo where uncommitted file count exceeds terminal height. The fix is a one-liner, but the bug is on the main rendering path.

internal/render/tui/repodetails/view.go — the trimming calculation in buildUncommittedFiles

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/render/tui/repodetails/view.go | Adds color-coded rendering for uncommitted files; introduces a regression in the file-count trimming calculation (len(files) instead of 2) that causes a slice-bounds panic when there are more files than the terminal height. |
| internal/render/tui/repodetails/view_test.go | New table-driven tests covering all status symbol cases; minor: error message hardcodes symbol=?? instead of interpolating the actual test symbol. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["View()"] --> B["buildUncommittedFiles()"]
    B --> C{len files == 0?}
    C -- yes --> D["return 'no changes'"]
    C -- no --> E["compute maxUncommitedFilesToShow\n(BUG: uses len(files) instead of 2)"]
    E --> F{trim needed?}
    F -- yes --> G["slice files to maxUncommitedFilesToShow\n panics if value is negative"]
    F -- no --> H["iterate all files"]
    G --> H
    H --> I["f[:2] changeSymbol"]
    I --> J["getFileStatusColor(symbol, colors)"]
    J --> K{symbol match}
    K -- "??" --> L["colors.Muted"]
    K -- "A_" --> M["colors.Success"]
    K -- "_D / D_" --> N["colors.Error"]
    K -- "R_" --> O["colors.Accent"]
    K -- "_U / U_" --> P["colors.Warning"]
    K -- "_M / M_" --> Q["colors.PopupTitle"]
    K -- other --> R["colors.Foreground"]
    L & M & N & O & P & Q & R --> S["render colored file line"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: updated changelog"](https://github.com/mabd-dev/reposcan/commit/1ea4139d2d0cb06bc35070b4a311d3ffde023e7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34695407)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->