### PR TITLE
feat(tui): add configurable VCS column

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,12 @@ jobs:
           ASSET_NAME="reposcan-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}"
           echo "Building $ASSET_NAME ..."
           go build \
-            -ldflags "-X github.com/mabd-dev/reposcan/cmd/reposcan.mixpanelToken=${{ secrets.MIXPANEL_TOKEN }}" \
+            -ldflags "-X main.mixpanelToken=${{ secrets.MIXPANEL_TOKEN }}" \
             -o "$ASSET_NAME" \
             .
 
       - name: Verify Binary
+        if: matrix.os != 'linux' || matrix.arch != 'arm64'
         run: ./reposcan-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }} version
 
       - name: Upload Binary to Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,12 +96,11 @@ jobs:
           ASSET_NAME="reposcan-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }}"
           echo "Building $ASSET_NAME ..."
           go build \
-            -ldflags "-X main.mixpanelToken=${{ secrets.MIXPANEL_TOKEN }}" \
+            -ldflags "-X github.com/mabd-dev/reposcan/cmd/reposcan.mixpanelToken=${{ secrets.MIXPANEL_TOKEN }}" \
             -o "$ASSET_NAME" \
             .
 
       - name: Verify Binary
-        if: matrix.os != 'linux' || matrix.arch != 'arm64'
         run: ./reposcan-${{ github.ref_name }}-${{ matrix.os }}-${{ matrix.arch }} version
 
       - name: Upload Binary to Release

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ dirIgnore = [
 type = "interactive"
 jsonPath = "/somewhere/nice"
 
+[tui]
+# Show the "VCS" column in the interactive table (default true).
+# Set to false to hide it, e.g. if you only use git.
+showVCS = true
+
 
 ```
 > You can still override everything via CLI flags.

--- a/internal/config/defaults_test.go
+++ b/internal/config/defaults_test.go
@@ -14,3 +14,40 @@ func TestDefaults_SensibleValues(t *testing.T) {
 		t.Fatalf("expected at least one default root when HOME is set")
 	}
 }
+
+func TestConfigShowVCSColumn(t *testing.T) {
+	tests := []struct {
+		name    string
+		showVCS *bool
+		want    bool
+	}{
+		{
+			name: "unset defaults to shown",
+			want: true,
+		},
+		{
+			name:    "explicit true is shown",
+			showVCS: boolPtr(true),
+			want:    true,
+		},
+		{
+			name:    "explicit false is hidden",
+			showVCS: boolPtr(false),
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{Tui: Tui{ShowVCS: tt.showVCS}}
+
+			if got := cfg.ShowVCSColumn(); got != tt.want {
+				t.Fatalf("expected ShowVCSColumn() = %v, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -11,6 +11,8 @@ type Config struct {
 
 	Output Output `toml:"output"`
 
+	Tui Tui `toml:"tui"`
+
 	// CountStashAsDirty, when true, makes repos with only stashed work count as
 	// dirty for IsDirty-based filtering (--filter dirty) and the dirty total.
 	// The --filter stash value is unaffected by this setting.
@@ -24,6 +26,18 @@ type Config struct {
 	NoTelemetry bool `toml:"no-telemetry"`
 
 	Version int `toml:"version"`
+}
+
+// Tui holds display options for the interactive renderer.
+type Tui struct {
+	ShowVCS *bool `toml:"showVCS,omitempty"`
+}
+
+// ShowVCSColumn reports whether the interactive table should render the VCS
+// column. An unset value defaults to true for compatibility with existing
+// config files.
+func (c Config) ShowVCSColumn() bool {
+	return c.Tui.ShowVCS == nil || *c.Tui.ShowVCS
 }
 
 // Defaults returns a Config populated with sensible defaults suitable for
@@ -99,11 +113,14 @@ func Defaults() Config {
 		JSONPath: "",
 	}
 
+	showVCS := true
+
 	return Config{
 		Roots:      roots,
 		DirIgnore:  defaultDirIgnore,
 		Only:       OnlyDirty,
 		Output:     newOutput,
+		Tui:        Tui{ShowVCS: &showVCS},
 		MaxWorkers: 8,
 		Debug:      false,
 		Version:    1,

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -30,6 +30,8 @@ type Config struct {
 
 // Tui holds display options for the interactive renderer.
 type Tui struct {
+	// ShowVCS controls whether the interactive table includes the VCS column.
+	// A nil value is treated as true so older config files continue to show it.
 	ShowVCS *bool `toml:"showVCS,omitempty"`
 }
 

--- a/internal/render/tui/main.go
+++ b/internal/render/tui/main.go
@@ -52,6 +52,9 @@ func Render(
 		r,
 		totalWidth*sizeReposTableWidthPercent/100,
 		totalHeight*sizeReposTableHeightPercent/100,
+		repostable.Options{
+			ShowVCS: configs.ShowVCSColumn(),
+		},
 	)
 
 	reposTableHeader := rth.Header{

--- a/internal/render/tui/repostable/main.go
+++ b/internal/render/tui/repostable/main.go
@@ -15,6 +15,7 @@ func New(
 	report report.ScanReport,
 	width int,
 	height int,
+	options Options,
 ) Model {
 	model := Model{
 		width:         width,
@@ -23,10 +24,11 @@ func New(
 		report:        report,
 		filteredRepos: report.RepoStates,
 		filterQuery:   "",
+		options:       options,
 	}
 
-	cols := createColumns(width)
-	rows := createRows(model.report.RepoStates, theme)
+	cols := createColumns(width, model.options)
+	rows := createRows(model.report.RepoStates, theme, model.options)
 
 	t := table.New(
 		table.WithColumns(cols),
@@ -40,7 +42,7 @@ func New(
 
 	// if no repos, show an empty placeholder row so the table renders nicely
 	if len(rows) == 0 {
-		t.SetRows([]table.Row{{"", "", "", ""}})
+		t.SetRows([]table.Row{make(table.Row, len(cols))})
 	}
 
 	t.SetStyles(table.Styles{
@@ -65,7 +67,7 @@ func (m *Model) UpdateWindowSize(width int, height int) Model {
 	m.height = height - 2 // border corners
 
 	m.tbl.SetHeight(m.height)
-	cols := createColumns(m.width)
+	cols := createColumns(m.width, m.options)
 	m.tbl.SetColumns(cols)
 
 	return *m
@@ -89,7 +91,7 @@ func (m *Model) Filter(query string) {
 
 	cursorPosition := m.tbl.Cursor()
 
-	rows := createRows(m.filteredRepos, m.theme)
+	rows := createRows(m.filteredRepos, m.theme, m.options)
 	m.tbl.SetRows(rows)
 
 	if cursorPosition < len(m.filteredRepos) {
@@ -108,7 +110,7 @@ func (m *Model) UpdateRepoState(index int, newState report.RepoState) {
 		m.report.RepoStates[originalIndex] = newState
 	}
 
-	rows := createRows(m.filteredRepos, m.theme)
+	rows := createRows(m.filteredRepos, m.theme, m.options)
 	m.tbl.SetRows(rows)
 }
 

--- a/internal/render/tui/repostable/types.go
+++ b/internal/render/tui/repostable/types.go
@@ -16,4 +16,10 @@ type Model struct {
 	report        report.ScanReport
 	filteredRepos []report.RepoState
 	filterQuery   string
+
+	options Options
+}
+
+type Options struct {
+	ShowVCS bool
 }

--- a/internal/render/tui/repostable/ui.go
+++ b/internal/render/tui/repostable/ui.go
@@ -103,13 +103,22 @@ func activeColumnDefs(options Options) []columnDef {
 		}
 		active = append(active, def)
 	}
+	redistributeHiddenWidth(active, hiddenWidth)
+
+	return active
+}
+
+func redistributeHiddenWidth(active []columnDef, hiddenWidth int) {
+	if hiddenWidth == 0 || len(active) == 0 {
+		return
+	}
 	for i := range active {
 		if active[i].expand {
 			active[i].widthPercent += hiddenWidth
+			return
 		}
 	}
-
-	return active
+	active[len(active)-1].widthPercent += hiddenWidth
 }
 
 func stashColumnStr(rs report.RepoState) string {

--- a/internal/render/tui/repostable/ui.go
+++ b/internal/render/tui/repostable/ui.go
@@ -18,36 +18,98 @@ const (
 	RemoteStateW = 36
 )
 
-func createColumns(maxWidth int) []table.Column {
-	repoW := maxWidth * RepoW / 100
-	branchW := maxWidth * BranchW / 100
-	vcsW := maxWidth * VCSW / 100
-	stashW := maxWidth * StashW / 100
-	remoteStateW := maxWidth * RemoteStateW / 100
-
-	return []table.Column{
-		{Title: "Repo", Width: repoW},
-		{Title: "Branch", Width: branchW},
-		{Title: "VCS", Width: vcsW},
-		{Title: "Stash", Width: stashW},
-		{Title: "State", Width: remoteStateW},
-	}
+type columnDef struct {
+	title        string
+	widthPercent int
+	show         func(Options) bool
+	cell         func(report.RepoState, theme.Theme) string
+	expand       bool
 }
 
-func createRows(repoStates []report.RepoState, theme theme.Theme) []table.Row {
-	rows := make([]table.Row, 0, len(repoStates))
-	for _, rs := range repoStates {
-		state := getStateColumnStr(rs, theme)
-
-		rows = append(rows, table.Row{
-			rs.Repo,
-			rs.Branch,
-			rs.VCSType,
-			stashColumnStr(rs),
-			state,
+func createColumns(maxWidth int, options Options) []table.Column {
+	defs := activeColumnDefs(options)
+	columns := make([]table.Column, 0, len(defs))
+	for _, def := range defs {
+		columns = append(columns, table.Column{
+			Title: def.title,
+			Width: maxWidth * def.widthPercent / 100,
 		})
 	}
+	return columns
+}
+
+func createRows(repoStates []report.RepoState, theme theme.Theme, options Options) []table.Row {
+	defs := activeColumnDefs(options)
+	rows := make([]table.Row, 0, len(repoStates))
+	for _, rs := range repoStates {
+		row := make(table.Row, 0, len(defs))
+		for _, def := range defs {
+			row = append(row, def.cell(rs, theme))
+		}
+		rows = append(rows, row)
+	}
 	return rows
+}
+
+func activeColumnDefs(options Options) []columnDef {
+	defs := []columnDef{
+		{
+			title:        "Repo",
+			widthPercent: RepoW,
+			cell: func(rs report.RepoState, _ theme.Theme) string {
+				return rs.Repo
+			},
+		},
+		{
+			title:        "Branch",
+			widthPercent: BranchW,
+			cell: func(rs report.RepoState, _ theme.Theme) string {
+				return rs.Branch
+			},
+		},
+		{
+			title:        "VCS",
+			widthPercent: VCSW,
+			show: func(options Options) bool {
+				return options.ShowVCS
+			},
+			cell: func(rs report.RepoState, _ theme.Theme) string {
+				return rs.VCSType
+			},
+		},
+		{
+			title:        "Stash",
+			widthPercent: StashW,
+			cell: func(rs report.RepoState, _ theme.Theme) string {
+				return stashColumnStr(rs)
+			},
+		},
+		{
+			title:        "State",
+			widthPercent: RemoteStateW,
+			expand:       true,
+			cell: func(rs report.RepoState, theme theme.Theme) string {
+				return getStateColumnStr(rs, theme)
+			},
+		},
+	}
+
+	hiddenWidth := 0
+	active := make([]columnDef, 0, len(defs))
+	for _, def := range defs {
+		if def.show != nil && !def.show(options) {
+			hiddenWidth += def.widthPercent
+			continue
+		}
+		active = append(active, def)
+	}
+	for i := range active {
+		if active[i].expand {
+			active[i].widthPercent += hiddenWidth
+		}
+	}
+
+	return active
 }
 
 func stashColumnStr(rs report.RepoState) string {

--- a/internal/render/tui/repostable/ui.go
+++ b/internal/render/tui/repostable/ui.go
@@ -21,9 +21,13 @@ const (
 type columnDef struct {
 	title        string
 	widthPercent int
-	show         func(Options) bool
-	cell         func(report.RepoState, theme.Theme) string
-	expand       bool
+	// show controls whether a column is included for the current options.
+	// A nil show function means the column is always visible.
+	show func(Options) bool
+	// cell renders the table cell for this column. It must not be nil because
+	// createRows calls it for every active column.
+	cell   func(report.RepoState, theme.Theme) string
+	expand bool
 }
 
 func createColumns(maxWidth int, options Options) []table.Column {

--- a/internal/render/tui/repostable/ui_test.go
+++ b/internal/render/tui/repostable/ui_test.go
@@ -82,3 +82,36 @@ func TestCreateRowsOmitsVCSValueWhenDisabled(t *testing.T) {
 		t.Fatalf("unexpected state cell: %q", rows[0][3])
 	}
 }
+
+func TestRedistributeHiddenWidthFallsBackToLastColumn(t *testing.T) {
+	active := []columnDef{
+		{title: "Repo", widthPercent: RepoW},
+		{title: "Branch", widthPercent: BranchW},
+	}
+
+	redistributeHiddenWidth(active, VCSW)
+
+	if active[0].widthPercent != RepoW {
+		t.Fatalf("expected first column width to stay %d, got %d", RepoW, active[0].widthPercent)
+	}
+	if active[1].widthPercent != BranchW+VCSW {
+		t.Fatalf("expected last column to reclaim hidden width, got %d", active[1].widthPercent)
+	}
+}
+
+func TestRedistributeHiddenWidthPrefersExpandableColumn(t *testing.T) {
+	active := []columnDef{
+		{title: "Repo", widthPercent: RepoW},
+		{title: "State", widthPercent: RemoteStateW, expand: true},
+		{title: "Branch", widthPercent: BranchW},
+	}
+
+	redistributeHiddenWidth(active, VCSW)
+
+	if active[1].widthPercent != RemoteStateW+VCSW {
+		t.Fatalf("expected expandable column to reclaim hidden width, got %d", active[1].widthPercent)
+	}
+	if active[2].widthPercent != BranchW {
+		t.Fatalf("expected last column width to stay %d, got %d", BranchW, active[2].widthPercent)
+	}
+}

--- a/internal/render/tui/repostable/ui_test.go
+++ b/internal/render/tui/repostable/ui_test.go
@@ -8,13 +8,29 @@ import (
 )
 
 func TestCreateColumnsIncludesVCSColumn(t *testing.T) {
-	columns := createColumns(100)
+	columns := createColumns(100, Options{ShowVCS: true})
 
 	if len(columns) != 5 {
 		t.Fatalf("expected 5 columns, got %d: %v", len(columns), columns)
 	}
 	if columns[2].Title != "VCS" {
 		t.Fatalf("expected third column to be VCS, got %q", columns[2].Title)
+	}
+}
+
+func TestCreateColumnsOmitsVCSColumnWhenDisabled(t *testing.T) {
+	columns := createColumns(100, Options{ShowVCS: false})
+
+	if len(columns) != 4 {
+		t.Fatalf("expected 4 columns, got %d: %v", len(columns), columns)
+	}
+	for _, c := range columns {
+		if c.Title == "VCS" {
+			t.Fatalf("did not expect a VCS column, got columns: %v", columns)
+		}
+	}
+	if columns[3].Title != "State" || columns[3].Width != RemoteStateW+VCSW {
+		t.Fatalf("expected State column to reclaim VCS width, got %+v", columns[3])
 	}
 }
 
@@ -28,7 +44,7 @@ func TestCreateRowsIncludesVCSValue(t *testing.T) {
 				{Remote: "origin", Ahead: 1, Behind: 2},
 			},
 		},
-	}, theme.Theme{})
+	}, theme.Theme{}, Options{ShowVCS: true})
 
 	if len(rows) != 1 {
 		t.Fatalf("expected 1 row, got %d", len(rows))
@@ -41,5 +57,28 @@ func TestCreateRowsIncludesVCSValue(t *testing.T) {
 	}
 	if rows[0][4] != "⏳0 ↑1 ↓2" {
 		t.Fatalf("unexpected state cell: %q", rows[0][4])
+	}
+}
+
+func TestCreateRowsOmitsVCSValueWhenDisabled(t *testing.T) {
+	rows := createRows([]report.RepoState{
+		{
+			Repo:    "jj-repo",
+			VCSType: "jj",
+			Branch:  "@",
+			RemoteStatus: []report.RemoteStatus{
+				{Remote: "origin", Ahead: 1, Behind: 2},
+			},
+		},
+	}, theme.Theme{}, Options{ShowVCS: false})
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if len(rows[0]) != 4 {
+		t.Fatalf("expected 4 cells, got %d: %v", len(rows[0]), rows[0])
+	}
+	if rows[0][3] != "⏳0 ↑1 ↓2" {
+		t.Fatalf("unexpected state cell: %q", rows[0][3])
 	}
 }

--- a/internal/render/tui/repostable/ui_test.go
+++ b/internal/render/tui/repostable/ui_test.go
@@ -34,6 +34,21 @@ func TestCreateColumnsOmitsVCSColumnWhenDisabled(t *testing.T) {
 	}
 }
 
+func TestActiveColumnDefsAllCellsDefined(t *testing.T) {
+	for _, options := range []Options{
+		{ShowVCS: true},
+		{ShowVCS: false},
+	} {
+		defs := activeColumnDefs(options)
+
+		for _, def := range defs {
+			if def.cell == nil {
+				t.Fatalf("expected %q column to define a cell renderer", def.title)
+			}
+		}
+	}
+}
+
 func TestCreateRowsIncludesVCSValue(t *testing.T) {
 	rows := createRows([]report.RepoState{
 		{

--- a/internal/vcs/jj/jj_test.go
+++ b/internal/vcs/jj/jj_test.go
@@ -1,6 +1,7 @@
 package jj
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -348,11 +349,11 @@ func TestProviderCheckRepoStateWarningsIncludeCommandFailureDetails(t *testing.T
 	}
 
 	warning := warnings[0]
+	command := strings.Join([]string{failingBinary, "-R", repoPath, "git", "remote", "list"}, " ")
 	wantParts := []string{
 		"Failed to get repo name for jj repo",
 		"path=" + repoPath,
-		`command="` + failingBinary,
-		` -R ` + repoPath + ` git remote list"`,
+		fmt.Sprintf("command=%q", command),
 		"failed:",
 	}
 

--- a/internal/vcs/jj/jj_test.go
+++ b/internal/vcs/jj/jj_test.go
@@ -338,13 +338,10 @@ func TestProviderCheckRepoStateWarnsWhenBinaryMissing(t *testing.T) {
 }
 
 func TestProviderCheckRepoStateWarningsIncludeCommandFailureDetails(t *testing.T) {
-	if _, err := exec.LookPath("false"); err != nil {
-		t.Skip("false binary not available")
-	}
-
 	repoPath := filepath.Join(t.TempDir(), "repo")
+	failingBinary := os.Args[0]
 
-	_, warnings := (&Provider{binary: "false"}).CheckRepoState(repoPath)
+	_, warnings := (&Provider{binary: failingBinary}).CheckRepoState(repoPath)
 
 	if len(warnings) == 0 {
 		t.Fatal("expected warnings")
@@ -354,8 +351,9 @@ func TestProviderCheckRepoStateWarningsIncludeCommandFailureDetails(t *testing.T
 	wantParts := []string{
 		"Failed to get repo name for jj repo",
 		"path=" + repoPath,
-		`command="false -R ` + repoPath + ` git remote list"`,
-		"failed: exit status 1",
+		`command="` + failingBinary,
+		` -R ` + repoPath + ` git remote list"`,
+		"failed:",
 	}
 
 	for _, want := range wantParts {

--- a/sample/config.toml
+++ b/sample/config.toml
@@ -84,3 +84,10 @@ type = "interactive"
 # output scan reports to this folder. All nested folders will be created
 # if they don't exist
 jsonPath = "somewhere/nice/"
+
+
+[tui]
+
+# Show the "VCS" column in the interactive table. Defaults to true.
+# Set to false to hide it. Only affects the `interactive` output.
+showVCS = true


### PR DESCRIPTION
# Pull Request

## Description

Adds a new `[tui] showVCS` configuration option for the interactive TUI output. This lets users hide the VCS column when they do not need it, while keeping the existing default behavior of showing the column. 

As there might be more similar TUI options in the future have implemented a small Config Layer that can be passed to the repo table renderer instead of passing the full application config around.

This should close #49 

## Changes Made

- Added `Tui` config support with `showVCS`, defaulting to `true` for existing configs.
- Passed a narrow `repostable.Options` value into the TUI table renderer instead of exposing full config to the table package.
- Refactored TUI table column rendering to use shared column definitions so headers and row cells stay aligned when columns are toggled.
- Updated README and sample config with the new `[tui] showVCS` option.
- Added tests for config defaulting and VCS column rendering behavior.

## Testing

- [x] Tested locally with example workflows
- [x] Added new tests
- [x] Tested with different `filters`, `output`, etc...

## Screenshots (if applicable)

ShowVCS = false
<img width="950" height="481" alt="image" src="https://github.com/user-attachments/assets/91bf99e6-8d65-4250-a919-9360c66f17e4" />

ShowVCS true
<img width="949" height="474" alt="image" src="https://github.com/user-attachments/assets/3680959f-1350-4f4a-8333-f292246ce047" />

## Checklist

- [X] I have starred the repository
- [X] My code follows the project's code style
- [X] I have updated the documentation (README, cli-flags, etc...)
- [X] My changes generate no new warnings
- [X] I have tested my changes in a real workflow
- [X] All tests pass locally

## Additional Notes

The config layer owns the defaulting behavior through ShowVCSColumn(), so existing config files without [tui] showVCS continue to show the VCS column.

The TUI table uses a small rendering options model and derives both headers and row cells from the same active column list. This avoids header/cell drift if more optional columns are added later.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `[tui] showVCS` configuration option that lets users hide the VCS column in the interactive table. It introduces a narrow `repostable.Options` struct so the table renderer doesn't take a full application config, and refactors column/row creation to share a single `columnDef` list so headers and cells always stay aligned when columns are toggled.

- `internal/config/types.go` adds a `Tui` struct with `ShowVCS *bool` and a `ShowVCSColumn()` method that defaults to `true` for backward compatibility; `internal/render/tui/repostable/ui.go` replaces the old parallel column/row arrays with a declarative `columnDef` slice and a `redistributeHiddenWidth` helper that reclaims space from hidden columns.
- `internal/vcs/jj/jj_test.go` replaces a dependency on the `/usr/bin/false` binary with `os.Args[0]` so the \"failing binary\" test works cross-platform; the expected error substring is loosened from `\"failed: exit status 1\"` to `\"failed:\"` because the test binary exits with status 2 on unrecognized flags.
- Tests covering all new code paths — config defaulting, column toggling, width redistribution, and row cell alignment — are added across three test files.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, defaults preserve existing behavior, and all toggling logic is well-covered by tests.

The config defaulting path (nil ShowVCS → show column) is exercised by dedicated unit tests. The column/row alignment refactor uses a shared columnDef list, eliminating any header-cell drift. Width redistribution is tested for both the expand-column and last-column fallback paths. The jj test fix removes a Unix-only binary dependency without introducing flakiness. No regressions were identified across the changed files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/config/types.go | Adds Tui struct with ShowVCS *bool and ShowVCSColumn() method; nil pointer defaults to true for backward compat with existing configs |
| internal/config/defaults_test.go | Adds table-driven test covering ShowVCSColumn() for nil, &true, and &false cases; boolPtr helper defined once in this file |
| internal/render/tui/repostable/ui.go | Replaces hardcoded column/row arrays with declarative columnDef slice; redistributeHiddenWidth now falls back to last column when no expand column exists |
| internal/render/tui/repostable/main.go | Threads Options through all createColumns/createRows call sites; empty placeholder row now uses make(table.Row, len(cols)) instead of hardcoded 4-element literal |
| internal/render/tui/repostable/types.go | Adds Options struct with ShowVCS bool and stores it in the Model |
| internal/render/tui/repostable/ui_test.go | Good coverage: VCS column omission, width reclaim, cell count with VCS off, and redistributeHiddenWidth fallback all tested |
| internal/render/tui/main.go | Passes repostable.Options{ShowVCS: configs.ShowVCSColumn()} cleanly; no full config exposed to renderer |
| internal/vcs/jj/jj_test.go | Replaces /usr/bin/false dependency with os.Args[0]; test binary exits status 2 on unrecognized -R flag so warnings are reliably produced cross-platform |
| README.md | Documents new [tui] showVCS option with default value and use-case note |
| sample/config.toml | Adds [tui] showVCS = true example with inline comment to the sample config |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["config.Config\n(TOML / CLI flags)"] -->|"ShowVCSColumn()"| B["repostable.Options\n{ShowVCS bool}"]
    B --> C["repostable.New()\nrepostable.Model"]
    C --> D["activeColumnDefs(options)"]
    D -->|"ShowVCS == true"| E["5 columnDefs\nRepo, Branch, VCS, Stash, State"]
    D -->|"ShowVCS == false"| F["4 columnDefs\nRepo, Branch, Stash, State"]
    F --> G["redistributeHiddenWidth\n+VCSW% to expand col or last col"]
    E --> H["createColumns → []table.Column"]
    G --> H
    E --> I["createRows → []table.Row"]
    F --> I
    H --> J["bubbles/table render"]
    I --> J
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(ui): cover VCS column review feedba..."](https://github.com/mabd-dev/reposcan/commit/0ac03381464db6ec99acfaa2e3a55465217b1f95) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34703940)</sub>

<!-- /greptile_comment -->